### PR TITLE
[#44] Add design system docs to Storybook

### DIFF
--- a/src/stories/design-system/Atoms.stories.tsx
+++ b/src/stories/design-system/Atoms.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta = {
+  title: 'Design System/Atoms',
+  parameters: { layout: 'padded' },
+};
+export default meta;
+type Story = StoryObj;
+
+const shadows = [
+  { name: 'shadow-sm', value: '0 1px 2px rgba(0,0,0,0.04)', usage: 'Subtle elevation' },
+  { name: 'shadow-md', value: '0 4px 12px rgba(0,0,0,0.06)', usage: 'Cards' },
+  { name: 'shadow-lg', value: '0 12px 32px rgba(0,0,0,0.08)', usage: 'Modals' },
+  { name: 'shadow-image', value: '0 8px 24px rgba(0,0,0,0.1)', usage: 'Lightbox image' },
+];
+
+const spacing = [
+  { token: 'space-1', value: '4px', usage: 'Micro gaps' },
+  { token: 'space-2', value: '8px', usage: 'Tight spacing' },
+  { token: 'space-4', value: '16px', usage: 'Default element gap' },
+  { token: 'space-6', value: '24px', usage: 'Nav gaps, gutter' },
+  { token: 'space-8', value: '32px', usage: 'Form group spacing' },
+  { token: 'space-12', value: '48px', usage: 'Section inner padding' },
+  { token: 'space-16', value: '64px', usage: 'Section margins' },
+  { token: 'space-20', value: '80px', usage: 'Large section padding' },
+  { token: 'space-32', value: '128px', usage: 'Page header top padding' },
+];
+
+const transitions = [
+  { name: 'Fast', duration: '150ms', easing: 'ease-out', usage: 'Micro interactions' },
+  { name: 'Normal', duration: '300ms', easing: 'cubic-bezier(0.23, 1, 0.32, 1)', usage: 'Most transitions' },
+  { name: 'Slow', duration: '600ms', easing: 'cubic-bezier(0.23, 1, 0.32, 1)', usage: 'Nav underline, hover effects' },
+  { name: 'Gallery hover', duration: '1000ms', easing: 'ease-out', usage: 'Gallery image scale' },
+];
+
+export const Shadows: Story = {
+  render: () => (
+    <div className="space-y-8 bg-[#f7f5f2] p-8 font-sans">
+      <div>
+        <h1 className="mb-1 text-2xl font-semibold text-[#1a1815]">Shadows</h1>
+        <p className="text-sm text-[#7a756e]">Elevation system — minimal and warm</p>
+      </div>
+      <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
+        {shadows.map((s) => (
+          <div key={s.name} className="flex flex-col gap-4">
+            <div
+              className="h-24 w-full rounded-sm bg-white"
+              style={{ boxShadow: s.value }}
+            />
+            <div>
+              <p className="text-sm font-semibold text-[#1a1815]">{s.name}</p>
+              <p className="font-mono text-xs text-[#a8a29e] break-all">{s.value}</p>
+              <p className="text-xs text-[#7a756e]">{s.usage}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+export const Spacing: Story = {
+  render: () => (
+    <div className="space-y-6 bg-white p-8 font-sans">
+      <div>
+        <h1 className="mb-1 text-2xl font-semibold text-[#1a1815]">Spacing</h1>
+        <p className="text-sm text-[#7a756e]">Key spacing values used across the design system</p>
+      </div>
+      <div className="space-y-3">
+        {spacing.map((s) => (
+          <div key={s.token} className="flex items-center gap-4">
+            <div className="w-28 shrink-0">
+              <p className="font-mono text-xs text-[#1a1815]">{s.token}</p>
+              <p className="font-mono text-xs text-[#a8a29e]">{s.value}</p>
+            </div>
+            <div className="flex items-center gap-3 flex-1">
+              <div
+                className="bg-accent shrink-0"
+                style={{ width: s.value, height: '20px', minWidth: '4px' }}
+              />
+              <p className="text-xs text-[#7a756e]">{s.usage}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+export const Transitions: Story = {
+  render: () => (
+    <div className="space-y-8 bg-white p-8 font-sans">
+      <div>
+        <h1 className="mb-1 text-2xl font-semibold text-[#1a1815]">Transitions</h1>
+        <p className="text-sm text-[#7a756e]">Hover over each card to preview the timing</p>
+      </div>
+      <div className="grid grid-cols-2 gap-6 sm:grid-cols-4">
+        {transitions.map((t) => (
+          <div key={t.name} className="group flex flex-col gap-4">
+            <div
+              className="flex h-24 w-full items-center justify-center rounded-sm border border-[#e0dbd4] bg-[#f7f5f2] text-sm text-[#7a756e] group-hover:bg-[#8b7355] group-hover:text-white"
+              style={{ transition: `background-color ${t.duration}, color ${t.duration}`, transitionTimingFunction: t.easing }}
+            >
+              Hover me
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-[#1a1815]">{t.name}</p>
+              <p className="font-mono text-xs text-[#a8a29e]">{t.duration}</p>
+              <p className="font-mono text-xs text-[#a8a29e] break-all">{t.easing}</p>
+              <p className="text-xs text-[#7a756e]">{t.usage}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="border-t border-[#e0dbd4] pt-6">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-widest text-[#7a756e]">Layout Constants</h2>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 text-sm">
+          <div><p className="font-mono text-xs text-[#1a1815]">Container</p><p className="text-xs text-[#7a756e]">1280px max-width</p></div>
+          <div><p className="font-mono text-xs text-[#1a1815]">Container wide</p><p className="text-xs text-[#7a756e]">1440px full-bleed</p></div>
+          <div><p className="font-mono text-xs text-[#1a1815]">Gallery gap</p><p className="text-xs text-[#7a756e]">14px between images</p></div>
+          <div><p className="font-mono text-xs text-[#1a1815]">Border radius</p><p className="text-xs text-[#7a756e]">2px (gallery items only)</p></div>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/stories/design-system/Colours.stories.tsx
+++ b/src/stories/design-system/Colours.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta = {
+  title: 'Design System/Colours',
+  parameters: { layout: 'padded' },
+};
+export default meta;
+type Story = StoryObj;
+
+const swatchGroups = [
+  {
+    label: 'Backgrounds',
+    swatches: [
+      { name: 'background', hex: '#f7f5f2', class: 'bg-background', usage: 'Primary page background' },
+      { name: 'background-alt', hex: '#efece7', class: 'bg-background-alt', usage: 'Alternating sections' },
+      { name: 'card', hex: '#ffffff', class: 'bg-card', usage: 'Cards, elevated surfaces' },
+      { name: 'surface', hex: '#e8e3dc', class: 'bg-surface', usage: 'Subtle surface fills' },
+    ],
+  },
+  {
+    label: 'Text',
+    swatches: [
+      { name: 'primary', hex: '#1a1815', class: 'text-primary', usage: 'Headlines, nav logo' },
+      { name: 'body-text', hex: '#3d3a36', class: 'text-body-text', usage: 'Paragraphs, body copy' },
+      { name: 'secondary', hex: '#7a756e', class: 'text-secondary', usage: 'Descriptions, nav links' },
+      { name: 'muted', hex: '#a8a29e', class: 'text-muted', usage: 'Labels, captions' },
+    ],
+  },
+  {
+    label: 'Accent & Borders',
+    swatches: [
+      { name: 'accent', hex: '#8b7355', class: 'bg-accent', usage: 'Links, decorative bars, hover states' },
+      { name: 'accent-hover', hex: '#73603f', class: 'bg-accent-hover', usage: 'Button/link hover' },
+      { name: 'border', hex: '#e0dbd4', class: 'border-border', usage: 'Standard dividers' },
+      { name: 'border-light', hex: '#ece8e2', class: 'border-border-light', usage: 'Subtle separators' },
+    ],
+  },
+  {
+    label: 'Overlays',
+    swatches: [
+      { name: 'overlay', hex: 'rgba(26,24,21,0.6)', class: '—', usage: 'Gallery item hover overlay' },
+      { name: 'overlay-heavy', hex: 'rgba(26,24,21,0.85)', class: '—', usage: 'Lightbox backdrop' },
+    ],
+  },
+];
+
+function Swatch({ name, hex, className: cls, usage }: { name: string; hex: string; className: string; usage: string }) {
+  const isOverlay = hex.startsWith('rgba');
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="h-16 w-full rounded-sm border border-[#e0dbd4]"
+        style={{ backgroundColor: hex }}
+      />
+      <div>
+        <p className="text-sm font-medium text-[#1a1815]">{name}</p>
+        <p className="font-mono text-xs text-[#7a756e]">{hex}</p>
+        {!isOverlay && <p className="font-mono text-xs text-[#a8a29e]">{cls}</p>}
+        <p className="text-xs text-[#7a756e]">{usage}</p>
+      </div>
+    </div>
+  );
+}
+
+export const AllColours: Story = {
+  name: 'All Colours',
+  render: () => (
+    <div className="space-y-10 bg-white p-8 font-sans">
+      <div>
+        <h1 className="mb-1 text-2xl font-semibold">Colour Palette</h1>
+        <p className="text-sm text-[#7a756e]">All design tokens defined in <code>src/styles/globals.css</code></p>
+      </div>
+      {swatchGroups.map((group) => (
+        <div key={group.label}>
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-[#7a756e]">{group.label}</h2>
+          <div className="grid grid-cols-2 gap-6 sm:grid-cols-4">
+            {group.swatches.map((s) => (
+              <Swatch key={s.name} name={s.name} hex={s.hex} className={s.class} usage={s.usage} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/stories/design-system/PageTemplates.stories.tsx
+++ b/src/stories/design-system/PageTemplates.stories.tsx
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta = {
+  title: 'Design System/Page Templates',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+type Story = StoryObj;
+
+const navLinks = [
+  { label: 'Portfolio', href: '/' },
+  { label: 'Food', href: '/food' },
+  { label: 'Advertising', href: '/advertising' },
+  { label: 'Clients', href: '/clients' },
+  { label: 'Contact', href: '/contact' },
+];
+
+function MockHeader({ activePath = '/' }: { activePath?: string }) {
+  return (
+    <header className="sticky top-0 z-50 border-b border-[#e0dbd4] bg-[#f7f5f2]">
+      <nav className="mx-auto flex max-w-[1280px] items-center justify-between px-6 py-4" aria-label="Main navigation">
+        <span className="font-display text-lg text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>
+          Neil Hurley
+        </span>
+        <ul className="flex items-center gap-6">
+          {navLinks.map((link) => {
+            const isActive = link.href === activePath;
+            return (
+              <li key={link.href}>
+                <span
+                  className={[
+                    'relative cursor-pointer text-xs uppercase tracking-[0.18em] font-body',
+                    isActive ? 'text-[#1a1815]' : 'text-[#7a756e]',
+                  ].join(' ')}
+                  style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}
+                >
+                  {link.label}
+                  {isActive && (
+                    <span className="absolute bottom-[-4px] left-0 h-[1px] w-full bg-[#8b7355]" />
+                  )}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </header>
+  );
+}
+
+function MockFooter() {
+  return (
+    <footer className="border-t border-[#e0dbd4] px-12 py-10">
+      <div className="mx-auto flex max-w-[1280px] items-center justify-between">
+        <span className="text-xs text-[#a8a29e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>
+          © {new Date().getFullYear()} Neil Hurley Photography
+        </span>
+        <div className="flex gap-6">
+          {['Privacy', 'Contact'].map((l) => (
+            <span key={l} className="cursor-pointer text-xs text-[#a8a29e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>{l}</span>
+          ))}
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export const HomePage: Story = {
+  name: 'Home Page',
+  render: () => (
+    <div className="min-h-screen bg-[#f7f5f2]">
+      <MockHeader activePath="/" />
+      {/* Hero */}
+      <div className="relative flex h-[85vh] min-h-[500px] items-end bg-[#efece7]">
+        <div className="absolute inset-0 flex items-center justify-center text-[#a8a29e] text-sm" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>
+          Hero image (85vh · full-width · object-cover · priority)
+        </div>
+        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-[#f7f5f2] to-transparent" />
+      </div>
+      {/* Section: Food */}
+      <section className="mx-auto max-w-[1280px] px-6 py-16">
+        <div className="mb-12 flex items-baseline justify-between">
+          <h2 className="text-[2rem] text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>Food{' '}<em style={{ color: '#8b7355' }}>&</em>{' '}Drink</h2>
+          <span className="cursor-pointer text-xs uppercase tracking-[0.18em] text-[#7a756e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>View Collection →</span>
+        </div>
+        <div className="grid grid-cols-3 gap-[14px]">
+          <div className="col-span-2 row-span-2 aspect-[4/5] bg-[#e8e3dc] rounded-sm" />
+          <div className="aspect-[4/5] bg-[#e8e3dc] rounded-sm" />
+          <div className="aspect-[4/5] bg-[#e8e3dc] rounded-sm" />
+        </div>
+      </section>
+      {/* Section: Advertising */}
+      <section className="mx-auto max-w-[1280px] px-6 pb-16">
+        <div className="mb-12 flex items-baseline justify-between">
+          <h2 className="text-[2rem] text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>Advertising{' '}<em style={{ color: '#8b7355' }}>&</em>{' '}Product</h2>
+          <span className="cursor-pointer text-xs uppercase tracking-[0.18em] text-[#7a756e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>View Collection →</span>
+        </div>
+        <div className="grid grid-cols-3 gap-[14px]">
+          {[...Array(3)].map((_, i) => <div key={i} className="aspect-[4/5] bg-[#e8e3dc] rounded-sm" />)}
+        </div>
+      </section>
+      <MockFooter />
+    </div>
+  ),
+};
+
+export const GalleryPage: Story = {
+  name: 'Gallery Page (Food / Advertising)',
+  render: () => (
+    <div className="min-h-screen bg-[#f7f5f2]">
+      <MockHeader activePath="/food" />
+      <main>
+        <div className="mx-auto max-w-[1280px] px-6 pb-8 pt-32">
+          <h1 className="text-[3.25rem] leading-tight text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>
+            Food{' '}<em style={{ color: '#8b7355' }}>&</em>{' '}Drink
+          </h1>
+          <p className="mt-4 max-w-[520px] text-base font-light text-[#7a756e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>
+            Crafting appetite through light, texture and composition.
+          </p>
+        </div>
+        <section className="mx-auto max-w-[1280px] px-6 pb-20">
+          <div className="grid grid-cols-3 gap-[14px]">
+            {[...Array(9)].map((_, i) => (
+              <div key={i} className="aspect-[4/5] bg-[#e8e3dc] rounded-sm" />
+            ))}
+          </div>
+        </section>
+      </main>
+      <MockFooter />
+    </div>
+  ),
+};
+
+export const ClientsPage: Story = {
+  name: 'Clients Page',
+  render: () => {
+    const clients = ['Hermès', 'Cartier', 'Chloé', 'Brown Thomas', 'Avoca', 'Kellogg\'s', 'Pepsi', 'American Express', 'Adidas', 'Flora', 'BBC', 'ITV'];
+    return (
+      <div className="min-h-screen bg-[#f7f5f2]">
+        <MockHeader activePath="/clients" />
+        <main>
+          <div className="mx-auto max-w-[1280px] px-6 pb-8 pt-32">
+            <h1 className="text-[3.25rem] leading-tight text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>
+              Selected Clients
+            </h1>
+            <p className="mt-4 max-w-[520px] text-base font-light text-[#7a756e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>
+              Trusted by leading international brands.
+            </p>
+          </div>
+          <section className="mx-auto max-w-[1280px] px-6 pb-20">
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-px bg-[#ece8e2]">
+              {clients.map((c) => (
+                <div key={c} className="flex items-center justify-center bg-[#f7f5f2] px-6 py-9 transition-colors hover:bg-white">
+                  <span className="text-center text-base text-[#7a756e]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>{c}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        </main>
+        <MockFooter />
+      </div>
+    );
+  },
+};
+
+export const ContactPage: Story = {
+  name: 'Contact Page',
+  render: () => (
+    <div className="min-h-screen bg-[#f7f5f2]">
+      <MockHeader activePath="/contact" />
+      <main>
+        <div className="mx-auto max-w-[1280px] px-6 pb-8 pt-32">
+          <h1 className="text-[3.25rem] leading-tight text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>
+            Contact
+          </h1>
+        </div>
+        <section className="mx-auto grid max-w-[1280px] grid-cols-2 gap-[80px] px-6 py-20">
+          <div>
+            <h2 className="mb-10 text-[2.5rem] leading-tight text-[#1a1815]" style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}>
+              Let's work together
+            </h2>
+            <dl className="space-y-6">
+              {[
+                { label: 'Phone', value: '+353 87 672 4862' },
+                { label: 'Email', value: 'info@neilhurley.com' },
+                { label: 'Location', value: 'Dublin, Ireland' },
+              ].map((d) => (
+                <div key={d.label}>
+                  <dt className="text-xs uppercase tracking-[0.18em] text-[#a8a29e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>{d.label}</dt>
+                  <dd className="mt-1 text-base text-[#3d3a36]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>{d.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+          <div className="flex items-start">
+            <p className="text-base font-light text-[#7a756e]" style={{ fontFamily: 'var(--font-outfit), system-ui, sans-serif' }}>
+              Available for commercial projects, editorial commissions, and advertising campaigns.
+            </p>
+          </div>
+        </section>
+      </main>
+      <MockFooter />
+    </div>
+  ),
+};

--- a/src/stories/design-system/Typography.stories.tsx
+++ b/src/stories/design-system/Typography.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta = {
+  title: 'Design System/Typography',
+  parameters: { layout: 'padded' },
+};
+export default meta;
+type Story = StoryObj;
+
+const typeScale = [
+  { name: 'Display 1', size: '4rem', px: '64px', font: 'Libre Baskerville', weight: '400', tracking: '-0.02em', usage: 'Hero title', sample: 'Still Life & Product' },
+  { name: 'Display 2', size: '3.25rem', px: '52px', font: 'Libre Baskerville', weight: '400', tracking: '-0.01em', usage: 'Page headers', sample: 'Food & Drink' },
+  { name: 'Display 3', size: '2rem', px: '32px', font: 'Libre Baskerville', weight: '400', tracking: 'normal', usage: 'Section titles', sample: 'Selected Work' },
+  { name: 'Heading 1', size: '1.5rem', px: '24px', font: 'Libre Baskerville', weight: '400', tracking: 'normal', usage: 'Card titles', sample: 'Artisan Produce' },
+  { name: 'Heading 2', size: '1.25rem', px: '20px', font: 'Libre Baskerville', weight: '400', tracking: 'normal', usage: 'Subsection titles', sample: 'Advertising' },
+  { name: 'Body', size: '1rem', px: '16px', font: 'Outfit', weight: '300', tracking: 'normal', usage: 'Paragraphs', sample: 'Crafting appetite through light, texture and composition.' },
+  { name: 'Body Small', size: '0.875rem', px: '14px', font: 'Outfit', weight: '300', tracking: 'normal', usage: 'Descriptions', sample: 'Still life photographer based in Dublin, Ireland.' },
+  { name: 'Label', size: '0.75rem', px: '12px', font: 'Outfit', weight: '400', tracking: '0.18em', usage: 'Nav links, uppercase', sample: 'PORTFOLIO' },
+  { name: 'Caption', size: '0.75rem', px: '12px', font: 'Outfit', weight: '300', tracking: '0.12em', usage: 'Footer, copyright', sample: '© 2024 Neil Hurley Photography' },
+];
+
+export const TypeScale: Story = {
+  name: 'Type Scale',
+  render: () => (
+    <div className="space-y-8 bg-white p-8">
+      <div>
+        <h1 className="mb-1 text-2xl font-semibold font-sans">Typography</h1>
+        <p className="text-sm text-[#7a756e] font-sans">Libre Baskerville (display) · Outfit (body/UI)</p>
+      </div>
+      <div className="divide-y divide-[#e0dbd4]">
+        {typeScale.map((t) => (
+          <div key={t.name} className="flex items-baseline gap-8 py-6">
+            <div className="w-36 shrink-0">
+              <p className="text-xs font-semibold font-sans text-[#1a1815]">{t.name}</p>
+              <p className="text-xs font-mono text-[#a8a29e]">{t.size} / {t.px}</p>
+              <p className="text-xs font-mono text-[#a8a29e]">{t.font.replace('Libre Baskerville', 'Baskerville')}</p>
+              <p className="text-xs font-mono text-[#a8a29e]">w{t.weight}</p>
+              {t.tracking !== 'normal' && <p className="text-xs font-mono text-[#a8a29e]">ls {t.tracking}</p>}
+              <p className="mt-1 text-xs text-[#7a756e] font-sans">{t.usage}</p>
+            </div>
+            <div
+              className="flex-1 text-[#1a1815] leading-tight"
+              style={{
+                fontSize: t.size,
+                fontFamily: t.font === 'Libre Baskerville' ? 'var(--font-baskerville), Georgia, serif' : 'var(--font-outfit), system-ui, sans-serif',
+                fontWeight: t.weight,
+                letterSpacing: t.tracking,
+              }}
+            >
+              {t.sample}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="border-t border-[#e0dbd4] pt-6">
+        <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-[#7a756e] font-sans">Ampersand Convention</h2>
+        <p className="text-sm text-[#7a756e] font-sans mb-4">Ampersands in headings use italic style and accent colour.</p>
+        <div
+          className="text-[2rem] leading-tight text-[#1a1815]"
+          style={{ fontFamily: 'var(--font-baskerville), Georgia, serif' }}
+        >
+          Food{' '}
+          <span style={{ fontStyle: 'italic', color: '#8b7355' }}>&</span>
+          {' '}Drink
+        </div>
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
Closes #44

Adds a **Design System** section to Storybook with four documented pages:

- **Colours** — all colour tokens with swatches, hex values, Tailwind class names and usage
- **Typography** — full type scale rendered live at actual sizes, plus ampersand convention
- **Atoms** — shadows (interactive preview), spacing scale with visual bars, transitions (hover demo), layout constants
- **Page Templates** — full-page wireframe layouts for Home, Gallery, Clients, and Contact pages showing component composition in context