### PR TITLE
fix: story image paths and animate-fade-in (#47 #48)

### DIFF
--- a/src/components/gallery-grid/gallery-grid.stories.tsx
+++ b/src/components/gallery-grid/gallery-grid.stories.tsx
@@ -15,31 +15,31 @@ type Story = StoryObj<typeof GalleryGrid>;
 const mockItems = [
   {
     id: 'food-1',
-    image: { src: '/resources/images/food/001.jpg', alt: 'Artisan produce' },
+    image: { src: '/images/food/02.jpg', alt: 'Artisan produce' },
     title: 'Artisan Produce',
     category: 'Food',
   },
   {
     id: 'food-2',
-    image: { src: '/resources/images/food/002.jpg', alt: 'Fresh bread' },
+    image: { src: '/images/food/04.jpg', alt: 'Fresh bread' },
     title: 'Fresh Bread',
     category: 'Food',
   },
   {
     id: 'food-3',
-    image: { src: '/resources/images/food/003.jpg', alt: 'Wine glass' },
+    image: { src: '/images/food/05.jpg', alt: 'Wine glass' },
     title: 'Wine Glass',
     category: 'Editorial',
   },
   {
     id: 'food-4',
-    image: { src: '/resources/images/food/004.jpg', alt: 'Cheese board' },
+    image: { src: '/images/food/10.jpg', alt: 'Cheese board' },
     title: 'Cheese Board',
     category: 'Food',
   },
   {
     id: 'food-5',
-    image: { src: '/resources/images/food/005.jpg', alt: 'Coffee setup' },
+    image: { src: '/images/food/11.jpg', alt: 'Coffee setup' },
     title: 'Coffee Setup',
     category: 'Product',
   },

--- a/src/components/hero/hero.stories.tsx
+++ b/src/components/hero/hero.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof Hero>;
 export const Default: Story = {
   args: {
     image: {
-      src: '/resources/images/hero/main.jpg',
+      src: '/images/product/1021.jpg',
       alt: 'Neil Hurley Photography',
     },
   },

--- a/src/components/lightbox/lightbox.stories.tsx
+++ b/src/components/lightbox/lightbox.stories.tsx
@@ -15,19 +15,19 @@ type Story = StoryObj<typeof Lightbox>;
 const mockItems = [
   {
     id: 'food-1',
-    image: { src: '/resources/images/food/001.jpg', alt: 'Artisan produce' },
+    image: { src: '/images/food/02.jpg', alt: 'Artisan produce' },
     title: 'Artisan Produce',
     category: 'Food',
   },
   {
     id: 'food-2',
-    image: { src: '/resources/images/food/002.jpg', alt: 'Fresh bread' },
+    image: { src: '/images/food/04.jpg', alt: 'Fresh bread' },
     title: 'Fresh Bread',
     category: 'Food',
   },
   {
     id: 'food-3',
-    image: { src: '/resources/images/food/003.jpg', alt: 'Wine glass' },
+    image: { src: '/images/food/05.jpg', alt: 'Wine glass' },
     title: 'Wine Glass',
     category: 'Editorial',
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -36,3 +36,18 @@
     -moz-osx-font-smoothing: grayscale;
   }
 }
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@utility animate-fade-in {
+  animation: fade-in 300ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @utility animate-fade-in {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Closes #47
Closes #48

- Fix image paths in hero, gallery-grid, and lightbox stories from `/resources/images/` → `/images/` using actual filenames from `public/images/`
- Add `@keyframes fade-in` and `@utility animate-fade-in` to `globals.css` so Lightbox fade-in works
- Respects `prefers-reduced-motion`