### PR TITLE
feat: enable Storybook autodocs

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,9 @@ const config: StorybookConfig = {
   "framework": "@storybook/nextjs-vite",
   "staticDirs": [
     "../public"
-  ]
+  ],
+  docs: {
+    autodocs: 'tag',
+  }
 };
 export default config;

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -14,6 +14,7 @@ const meta: Meta<typeof Button> = {
       options: ['sm', 'default', 'lg'],
     },
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/client-grid/client-grid.stories.tsx
+++ b/src/components/client-grid/client-grid.stories.tsx
@@ -4,6 +4,7 @@ import { ClientGrid } from './client-grid';
 const meta: Meta<typeof ClientGrid> = {
   title: 'Components/ClientGrid',
   component: ClientGrid,
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/contact-section/contact-section.stories.tsx
+++ b/src/components/contact-section/contact-section.stories.tsx
@@ -4,6 +4,7 @@ import { ContactSection } from './contact-section';
 const meta: Meta<typeof ContactSection> = {
   title: 'Components/ContactSection',
   component: ContactSection,
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/gallery-grid/gallery-grid.stories.tsx
+++ b/src/components/gallery-grid/gallery-grid.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof GalleryGrid> = {
   parameters: {
     layout: 'padded',
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/hero/hero.stories.tsx
+++ b/src/components/hero/hero.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof Hero> = {
   parameters: {
     layout: 'fullscreen',
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/lightbox/lightbox.stories.tsx
+++ b/src/components/lightbox/lightbox.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof Lightbox> = {
   parameters: {
     layout: 'fullscreen',
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/mobile-nav/mobile-nav.stories.tsx
+++ b/src/components/mobile-nav/mobile-nav.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof MobileNav> = {
   parameters: {
     layout: 'fullscreen',
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/page-header/page-header.stories.tsx
+++ b/src/components/page-header/page-header.stories.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from './page-header';
 const meta: Meta<typeof PageHeader> = {
   title: 'Components/PageHeader',
   component: PageHeader,
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/section-header/section-header.stories.tsx
+++ b/src/components/section-header/section-header.stories.tsx
@@ -4,6 +4,7 @@ import { SectionHeader } from './section-header';
 const meta: Meta<typeof SectionHeader> = {
   title: 'Components/SectionHeader',
   component: SectionHeader,
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/site-footer/site-footer.stories.tsx
+++ b/src/components/site-footer/site-footer.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof SiteFooter> = {
   parameters: {
     layout: 'fullscreen',
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/components/site-header/site-header.stories.tsx
+++ b/src/components/site-header/site-header.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof SiteHeader> = {
   parameters: {
     layout: 'fullscreen',
   },
+  tags: ['autodocs'],
 };
 
 export default meta;


### PR DESCRIPTION
- Sets `docs: { autodocs: 'tag' }` in `.storybook/main.ts`
- Adds `tags: ['autodocs']` to all 11 component story `meta` objects
- Every component in Storybook now gets an auto-generated Docs page showing props table, description, and all stories
- No code changes — Storybook config only, typecheck passes