### PR TITLE
feat: Storybook intro page and sidebar ordering

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,11 @@ import type { Preview } from '@storybook/nextjs-vite';
 
 const preview: Preview = {
   parameters: {
+    options: {
+      storySort: {
+        order: ['Introduction', 'Design System', ['Colours', 'Typography', 'Atoms', 'Page Templates'], 'Components', '*'],
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -1,0 +1,255 @@
+{/* Introduction.mdx */}
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Introduction" />
+
+<div style={{
+  background: '#f7f5f2',
+  minHeight: '100vh',
+  padding: '0',
+  fontFamily: "'Outfit', system-ui, sans-serif",
+}}>
+
+  {/* Hero bar */}
+  <div style={{
+    background: '#1a1815',
+    padding: '80px 64px 64px',
+    borderBottom: '1px solid #e0dbd4',
+  }}>
+    <div style={{ maxWidth: 900 }}>
+      <p style={{
+        fontFamily: "'Libre Baskerville', Georgia, serif",
+        fontSize: '0.75rem',
+        letterSpacing: '0.25em',
+        textTransform: 'uppercase',
+        color: '#8b7355',
+        marginBottom: 24,
+        fontWeight: 400,
+      }}>
+        Component Library
+      </p>
+      <h1 style={{
+        fontFamily: "'Libre Baskerville', Georgia, serif",
+        fontSize: 'clamp(2.5rem, 5vw, 4rem)',
+        fontWeight: 400,
+        color: '#f7f5f2',
+        lineHeight: 1.1,
+        letterSpacing: '-0.02em',
+        margin: '0 0 24px',
+      }}>
+        Neil Hurley<br />
+        Photography
+      </h1>
+      <p style={{
+        fontSize: '1rem',
+        fontWeight: 300,
+        color: '#7a756e',
+        maxWidth: 520,
+        lineHeight: 1.7,
+        margin: 0,
+      }}>
+        Design system and component library for the Neil Hurley Photography
+        website rebuild. Built with Next.js 16, Tailwind CSS 4, and TypeScript.
+      </p>
+    </div>
+  </div>
+
+  {/* Content */}
+  <div style={{ padding: '64px', maxWidth: 'calc(900px + 128px)' }}>
+
+    {/* Design direction */}
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+      gap: 2,
+      marginBottom: 64,
+      background: '#e0dbd4',
+    }}>
+      {[
+        { label: 'Design Direction', value: 'Clean White Gallery' },
+        { label: 'Framework', value: 'Next.js 16 · App Router' },
+        { label: 'Styling', value: 'Tailwind CSS 4' },
+        { label: 'Language', value: 'TypeScript 5' },
+      ].map(item => (
+        <div key={item.label} style={{
+          background: '#f7f5f2',
+          padding: '28px 32px',
+        }}>
+          <p style={{
+            fontSize: '0.75rem',
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: '#a8a29e',
+            margin: '0 0 8px',
+            fontWeight: 400,
+          }}>
+            {item.label}
+          </p>
+          <p style={{
+            fontSize: '1rem',
+            color: '#1a1815',
+            margin: 0,
+            fontWeight: 300,
+          }}>
+            {item.value}
+          </p>
+        </div>
+      ))}
+    </div>
+
+    {/* Section guide */}
+    <h2 style={{
+      fontFamily: "'Libre Baskerville', Georgia, serif",
+      fontSize: '1.5rem',
+      fontWeight: 400,
+      color: '#1a1815',
+      margin: '0 0 32px',
+    }}>
+      What's in here
+    </h2>
+
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2, marginBottom: 64 }}>
+      {[
+        {
+          number: '01',
+          title: 'Design System',
+          description: 'Colour palette, typography scale, spacing tokens, shadows, transitions, and full-page layout templates. The source of truth for all visual decisions.',
+          items: ['Colours', 'Typography', 'Atoms', 'Page Templates'],
+        },
+        {
+          number: '02',
+          title: 'Components',
+          description: 'Every UI component with live stories covering all variants, states, and responsive behaviour. Each component has an auto-generated Docs page.',
+          items: ['Button', 'SiteHeader', 'Hero', 'GalleryGrid', 'Lightbox', '+ 7 more'],
+        },
+      ].map(section => (
+        <div key={section.number} style={{
+          display: 'grid',
+          gridTemplateColumns: '80px 1fr',
+          gap: 0,
+          background: '#ffffff',
+          border: '1px solid #e0dbd4',
+        }}>
+          <div style={{
+            padding: '32px 24px',
+            borderRight: '1px solid #e0dbd4',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'center',
+          }}>
+            <span style={{
+              fontFamily: "'Libre Baskerville', Georgia, serif",
+              fontSize: '1.5rem',
+              color: '#8b7355',
+              fontWeight: 400,
+            }}>
+              {section.number}
+            </span>
+          </div>
+          <div style={{ padding: '32px 36px' }}>
+            <h3 style={{
+              fontFamily: "'Libre Baskerville', Georgia, serif",
+              fontSize: '1.25rem',
+              fontWeight: 400,
+              color: '#1a1815',
+              margin: '0 0 12px',
+            }}>
+              {section.title}
+            </h3>
+            <p style={{
+              fontSize: '0.875rem',
+              fontWeight: 300,
+              color: '#7a756e',
+              lineHeight: 1.7,
+              margin: '0 0 20px',
+            }}>
+              {section.description}
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              {section.items.map(item => (
+                <span key={item} style={{
+                  fontSize: '0.75rem',
+                  letterSpacing: '0.1em',
+                  color: '#7a756e',
+                  background: '#f7f5f2',
+                  border: '1px solid #e0dbd4',
+                  padding: '4px 12px',
+                }}>
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    {/* Conventions */}
+    <h2 style={{
+      fontFamily: "'Libre Baskerville', Georgia, serif",
+      fontSize: '1.5rem',
+      fontWeight: 400,
+      color: '#1a1815',
+      margin: '0 0 24px',
+    }}>
+      Component conventions
+    </h2>
+    <div style={{
+      background: '#1a1815',
+      padding: '32px 36px',
+      marginBottom: 64,
+    }}>
+      {[
+        ['Structure', 'src/components/<name>/index.ts · <name>.tsx · <name>.stories.tsx · <name>.test.tsx'],
+        ['Styling', 'Tailwind classes only — no inline styles, no CSS modules'],
+        ['Images', 'next/image for all images, with alt text and sizes prop'],
+        ['Types', 'Shared interfaces from @/components/types'],
+        ['Interactivity', "'use client' only where required — prefer server components"],
+        ['Docs', 'TSDoc on all props interfaces and component functions'],
+      ].map(([label, value]) => (
+        <div key={label} style={{
+          display: 'grid',
+          gridTemplateColumns: '140px 1fr',
+          gap: 16,
+          padding: '14px 0',
+          borderBottom: '1px solid #3d3a36',
+        }}>
+          <span style={{
+            fontSize: '0.75rem',
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
+            color: '#8b7355',
+            fontWeight: 400,
+          }}>
+            {label}
+          </span>
+          <span style={{
+            fontSize: '0.8125rem',
+            color: '#efece7',
+            fontWeight: 300,
+            fontFamily: "'Outfit', monospace",
+          }}>
+            {value}
+          </span>
+        </div>
+      ))}
+    </div>
+
+    {/* Footer */}
+    <div style={{
+      borderTop: '1px solid #e0dbd4',
+      paddingTop: 32,
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }}>
+      <span style={{ fontSize: '0.75rem', color: '#a8a29e', letterSpacing: '0.1em' }}>
+        Neil Hurley Photography · Component Library
+      </span>
+      <span style={{ fontSize: '0.75rem', color: '#a8a29e' }}>
+        Next.js 16 · Tailwind 4 · Storybook 10
+      </span>
+    </div>
+
+  </div>
+</div>


### PR DESCRIPTION
- Adds a stylised `Introduction.mdx` page as the Storybook landing page — dark hero banner, design direction metadata, section guide, component conventions reference
- Configures `storySort` in preview.ts to enforce sidebar order: Introduction → Design System (Colours, Typography, Atoms, Page Templates) → Components
- Autodocs already enabled in previous PR