### PR TITLE
feat(pages): Phase 3 – layout, home, food, advertising, clients, contact

### DIFF
--- a/src/app/advertising/page.tsx
+++ b/src/app/advertising/page.tsx
@@ -1,0 +1,19 @@
+import { PageHeader } from '@/components/page-header';
+import { GalleryGrid } from '@/components/gallery-grid';
+import advertisingData from '@/data/advertising.json';
+
+export const metadata = {
+  title: 'Advertising & Product — Neil Hurley Photography',
+  description: advertisingData.header.description,
+};
+
+export default function AdvertisingPage() {
+  return (
+    <>
+      <PageHeader title={advertisingData.header.title} description={advertisingData.header.description} />
+      <div className="mx-auto max-w-[1280px] px-6 pb-20">
+        <GalleryGrid items={advertisingData.items} variant="uniform" />
+      </div>
+    </>
+  );
+}

--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -1,0 +1,19 @@
+import { PageHeader } from '@/components/page-header';
+import { ClientGrid } from '@/components/client-grid';
+import clientsData from '@/data/clients.json';
+
+export const metadata = {
+  title: 'Clients — Neil Hurley Photography',
+  description: 'Selected clients of Neil Hurley Photography.',
+};
+
+export default function ClientsPage() {
+  return (
+    <>
+      <PageHeader title="Clients" description="A selection of brands and agencies worked with over the years." />
+      <div className="mx-auto max-w-[1280px] px-6 pb-20">
+        <ClientGrid clients={clientsData.clients} />
+      </div>
+    </>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,17 @@
+import { PageHeader } from '@/components/page-header';
+import { ContactSection } from '@/components/contact-section';
+import contactData from '@/data/contact.json';
+
+export const metadata = {
+  title: 'Contact — Neil Hurley Photography',
+  description: 'Get in touch with Neil Hurley Photography.',
+};
+
+export default function ContactPage() {
+  return (
+    <>
+      <PageHeader title="Contact" description="Interested in working together? Get in touch." />
+      <ContactSection heading={contactData.heading} details={contactData.details} />
+    </>
+  );
+}

--- a/src/app/food/page.tsx
+++ b/src/app/food/page.tsx
@@ -1,0 +1,19 @@
+import { PageHeader } from '@/components/page-header';
+import { GalleryGrid } from '@/components/gallery-grid';
+import foodData from '@/data/food.json';
+
+export const metadata = {
+  title: 'Food & Drink — Neil Hurley Photography',
+  description: foodData.header.description,
+};
+
+export default function FoodPage() {
+  return (
+    <>
+      <PageHeader title={foodData.header.title} description={foodData.header.description} />
+      <div className="mx-auto max-w-[1280px] px-6 pb-20">
+        <GalleryGrid items={foodData.items} variant="uniform" />
+      </div>
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
 import '../styles/globals.css';
+import { SiteHeader } from '@/components/site-header';
+import { SiteFooter } from '@/components/site-footer';
+import navigationData from '@/data/navigation.json';
 
 export const metadata: Metadata = {
   title: 'Neil Hurley Photography',
@@ -21,7 +24,11 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="font-body">{children}</body>
+      <body className="font-body">
+        <SiteHeader links={navigationData.links} />
+        <main>{children}</main>
+        <SiteFooter />
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,55 @@
+import { Hero } from '@/components/hero';
+import { GalleryGrid } from '@/components/gallery-grid';
+import { SectionHeader } from '@/components/section-header';
+import { ClientGrid } from '@/components/client-grid';
+import { ContactSection } from '@/components/contact-section';
+import homeData from '@/data/home.json';
+import foodData from '@/data/food.json';
+import advertisingData from '@/data/advertising.json';
+import clientsData from '@/data/clients.json';
+
+const FOOD_PREVIEW_ITEMS = 5;
+const ADV_PREVIEW_ITEMS = 3;
+const CLIENTS_PREVIEW_COUNT = 8;
+
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="font-display text-4xl text-primary">Neil Hurley Photography</h1>
-    </main>
+    <>
+      <Hero image={homeData.hero.image} />
+
+      <section className="mx-auto max-w-[1280px] px-6 py-20">
+        <SectionHeader
+          title="Food & Drink"
+          viewAllLink={{ label: 'View Collection', href: '/food' }}
+        />
+        <GalleryGrid items={foodData.items.slice(0, FOOD_PREVIEW_ITEMS)} variant="asymmetric" />
+      </section>
+
+      <section className="bg-background-alt py-20">
+        <div className="mx-auto max-w-[1280px] px-6">
+          <SectionHeader
+            title="Advertising & Product"
+            viewAllLink={{ label: 'View Collection', href: '/advertising' }}
+          />
+          <GalleryGrid items={advertisingData.items.slice(0, ADV_PREVIEW_ITEMS)} variant="uniform" />
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-[1280px] px-6 py-20">
+        <SectionHeader
+          title="Selected Clients"
+          viewAllLink={{ label: 'View All', href: '/clients' }}
+        />
+        <ClientGrid clients={clientsData.clients.slice(0, CLIENTS_PREVIEW_COUNT)} />
+      </section>
+
+      <ContactSection
+        heading="Let's work together"
+        details={[
+          { label: 'Email', value: 'info@neilhurley.com', href: 'mailto:info@neilhurley.com' },
+          { label: 'Location', value: 'Dublin, Ireland' },
+        ]}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- `layout.tsx` — SiteHeader + SiteFooter wrapping every page, nav from `navigation.json`
- `page.tsx` — Hero → Food & Drink preview (5 items) → Advertising preview (3) → Clients preview (8) → Contact teaser
- `food/page.tsx` — PageHeader + full GalleryGrid (22 items) with Lightbox
- `advertising/page.tsx` — PageHeader + full GalleryGrid (33 items) with Lightbox
- `clients/page.tsx` — PageHeader + ClientGrid (26 clients)
- `contact/page.tsx` — PageHeader + ContactSection

All pages are server components. GalleryGrid handles lightbox state internally as a client component.

Closes #54, Closes #55, Closes #56, Closes #57, Closes #58, Closes #59

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` all 76 tests pass
- [ ] Home page: Hero, two gallery sections, clients grid, contact teaser render
- [ ] `/food` — 22 items, Lightbox opens on click
- [ ] `/advertising` — 33 items, Lightbox opens on click
- [ ] `/clients` — 26 client names
- [ ] `/contact` — phone, email, location
- [ ] SiteHeader and SiteFooter on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)