### PR TITLE
feat(seo): sitemap.xml and robots.txt (#73 #74)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+import { siteConfig } from '@/lib/site-config';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteConfig.baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from 'next';
+import { siteConfig } from '@/lib/site-config';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteConfig.baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${siteConfig.baseUrl}/food`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${siteConfig.baseUrl}/advertising`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${siteConfig.baseUrl}/clients`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${siteConfig.baseUrl}/contact`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
Closes #73, Closes #74

- `src/app/sitemap.ts` — Next.js MetadataRoute.Sitemap covering all 5 routes with priority/changeFrequency
- `src/app/robots.ts` — allow all crawlers, sitemap URL from siteConfig

Both output as static routes: `/sitemap.xml` and `/robots.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)