### PR TITLE
fix(a11y): add type=button to lightbox and error boundary buttons

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -13,8 +13,9 @@ export default function Error({
         An unexpected error occurred. Please try again.
       </p>
       <button
+        type="button"
         onClick={reset}
-        className="font-body text-xs uppercase tracking-[0.2em] text-accent hover:text-accent-hover transition-colors duration-300"
+        className="font-body text-xs uppercase tracking-[0.2em] text-accent hover:text-accent-hover transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
       >
         Try again
       </button>

--- a/src/components/lightbox/lightbox.tsx
+++ b/src/components/lightbox/lightbox.tsx
@@ -78,6 +78,7 @@ export function Lightbox({
       className="fixed inset-0 z-100 bg-[rgba(26,24,21,0.85)] backdrop-blur-3xl flex items-center justify-center animate-fade-in"
     >
       <button
+        type="button"
         onClick={onClose}
         aria-label="Close lightbox"
         className="absolute top-6 right-6 text-card text-2xl font-body cursor-pointer hover:text-muted transition-colors duration-300 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(26,24,21,0.85)]"
@@ -86,6 +87,7 @@ export function Lightbox({
       </button>
 
       <button
+        type="button"
         onClick={handlePrev}
         aria-label="Previous image"
         className="absolute left-4 md:left-8 w-12 h-12 rounded-full bg-[rgba(247,245,242,0.1)] backdrop-blur-sm flex items-center justify-center text-card hover:bg-[rgba(247,245,242,0.2)] transition-colors duration-300 cursor-pointer z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(26,24,21,0.85)]"
@@ -117,6 +119,7 @@ export function Lightbox({
       </div>
 
       <button
+        type="button"
         onClick={handleNext}
         aria-label="Next image"
         className="absolute right-4 md:right-8 w-12 h-12 rounded-full bg-[rgba(247,245,242,0.1)] backdrop-blur-sm flex items-center justify-center text-card hover:bg-[rgba(247,245,242,0.2)] transition-colors duration-300 cursor-pointer z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(26,24,21,0.85)]"


### PR DESCRIPTION
## Summary
- Add `type="button"` to all three `<button>` elements in the Lightbox component (close, prev, next)
- Add `type="button"` and `focus-visible` ring to the reset button in `error.tsx`

Fixes Lighthouse best-practices audit flag for buttons without explicit type attributes.

## Test plan
- [ ] CI passes (lint, typecheck, test, lighthouse)
- [ ] Lightbox buttons work correctly in browser
- [ ] Error boundary reset button is keyboard-accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)