### PR TITLE
fix(perf): pass accurate sizes to asymmetric GalleryItem for LCP

### DIFF
--- a/src/components/gallery-grid/gallery-grid.tsx
+++ b/src/components/gallery-grid/gallery-grid.tsx
@@ -33,6 +33,11 @@ export function GalleryGrid({ items, variant }: GalleryGridProps) {
             item={item}
             onClick={() => setLightboxIndex(index)}
             priority={index === 0}
+            sizes={
+              variant === 'asymmetric' && index === 0
+                ? '(max-width: 768px) 100vw, (max-width: 1280px) 66vw, 853px'
+                : undefined
+            }
             className={
               variant === 'asymmetric' && index === 0
                 ? 'md:col-span-2 md:row-span-2'

--- a/src/components/gallery-grid/gallery-item.tsx
+++ b/src/components/gallery-grid/gallery-item.tsx
@@ -13,6 +13,8 @@ interface GalleryItemProps {
   onClick: () => void;
   /** Whether to prioritise loading this image. */
   priority?: boolean;
+  /** Responsive sizes attribute for the image. */
+  sizes?: string;
   /** Additional CSS classes. */
   className?: string;
 }
@@ -27,6 +29,7 @@ export function GalleryItem({
   item,
   onClick,
   priority = false,
+  sizes = '(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw',
   className = '',
 }: GalleryItemProps) {
   return (
@@ -40,7 +43,7 @@ export function GalleryItem({
         src={item.image.src}
         alt={item.image.alt}
         fill
-        sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw"
+        sizes={sizes}
         className="object-cover transition-transform duration-1000 ease-out group-hover:scale-[1.03]"
         priority={priority}
       />


### PR DESCRIPTION
## Summary
- Adds a `sizes` prop to `GalleryItem` with a sensible default, replacing the hardcoded value
- Passes `sizes="(max-width: 768px) 100vw, (max-width: 1280px) 66vw, 853px"` for the first item in the `asymmetric` variant, matching its actual rendered width (~2/3 of the grid)
- Fixes Next.js serving an undersized image for the LCP element

Closes #81

## Test plan
- [ ] Verify asymmetric grid first image loads correct resolution at desktop
- [ ] Verify other grid items still use default sizes
- [ ] Lighthouse performance score should improve (no more undersized LCP image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)