### PR TITLE
feat: hero redesign — animated name, tagline & specialty links

### DIFF
--- a/.ai-devkit.json
+++ b/.ai-devkit.json
@@ -13,7 +13,7 @@
     "monitoring"
   ],
   "createdAt": "2026-03-05T16:37:08.858Z",
-  "updatedAt": "2026-03-05T16:46:48.437Z",
+  "updatedAt": "2026-03-05T17:00:34.016Z",
   "skills": [
     {
       "registry": "anthropics/skills",
@@ -22,6 +22,10 @@
     {
       "registry": "sickn33/antigravity-awesome-skills",
       "name": "figma-automation"
+    },
+    {
+      "registry": "codeaholicguy/ai-devkit",
+      "name": "memory"
     }
   ]
 }

--- a/.ai-devkit.json
+++ b/.ai-devkit.json
@@ -13,5 +13,15 @@
     "monitoring"
   ],
   "createdAt": "2026-03-05T16:37:08.858Z",
-  "updatedAt": "2026-03-05T16:37:08.962Z"
+  "updatedAt": "2026-03-05T16:46:48.437Z",
+  "skills": [
+    {
+      "registry": "anthropics/skills",
+      "name": "frontend-design"
+    },
+    {
+      "registry": "sickn33/antigravity-awesome-skills",
+      "name": "figma-automation"
+    }
+  ]
 }

--- a/.claude/skills/frontend-design
+++ b/.claude/skills/frontend-design
@@ -1,0 +1,1 @@
+/home/node/.ai-devkit/skills/anthropics/skills/skills/frontend-design

--- a/.claude/skills/memory
+++ b/.claude/skills/memory
@@ -1,0 +1,1 @@
+/home/node/.ai-devkit/skills/codeaholicguy/ai-devkit/skills/memory

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,15 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    },
+    "memory": {
+      "command": "npx",
+      "args": [
+        "@ai-devkit/memory"
+      ]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ pnpm lint             # ESLint
 pnpm typecheck        # TypeScript type check
 pnpm format           # Prettier
 pnpm build            # Production build
-pnpm e2e              # Playwright E2E tests
+pnpm test:coverage    # Unit tests with v8 coverage
 ```
 
 To run a single test file: `pnpm vitest run --project unit src/components/button/button.test.tsx`
@@ -25,7 +25,7 @@ To run a single test file: `pnpm vitest run --project unit src/components/button
 
 **Data layer** — all content lives in `src/data/*.json` (no CMS/API). Pages import JSON directly.
 
-**Styling** — Tailwind CSS 4 with CSS-first configuration. Design tokens are defined in `src/styles/globals.css` using `@theme {}`. There is no `tailwind.config.js` — use CSS variables from `@theme` for colors and fonts. Never use inline styles or CSS modules.
+**Styling** — Tailwind CSS 4 with CSS-first configuration. Design tokens are defined in `src/styles/globals.css` using `@theme {}`. There is no `tailwind.config.js` — use CSS variables from `@theme` for colors and fonts. Never use inline styles or CSS modules. A custom `animate-fade-in` utility is defined there for entrance animations. Max content width is `max-w-[1280px]` (standard) or `max-w-[1440px]` (wide); always pair with `px-6`.
 
 **Shared types** — `src/components/types/index.ts` defines `ImageType`, `GalleryItemType`, `LinkType`, etc. Import from there rather than redefining.
 
@@ -34,6 +34,16 @@ To run a single test file: `pnpm vitest run --project unit src/components/button
 **Path alias** — `@/` maps to `src/`. Use it for all internal imports.
 
 **Site metadata** — `src/lib/site-config.ts` exports `siteConfig` (name, baseUrl, description). Use it in `metadata` exports instead of hardcoding strings.
+
+## Pages
+
+- `/` — homepage with Hero, Food preview (asymmetric, 5 items), Advertising preview (uniform, 3 items), Clients preview, ContactSection
+- `/food` — full Food & Drink gallery (uniform)
+- `/advertising` — full Advertising & Product gallery (uniform)
+- `/clients` — full client list
+- `/contact` — contact page
+
+All pages are server components that import JSON directly. The `GalleryGrid` component is a client component (it manages lightbox open state), so pages that include it still render as server components — Next.js handles the boundary automatically.
 
 ## Component Conventions
 
@@ -47,13 +57,14 @@ Test assertions use semantic queries (`getByRole`, `getByAltText`, `getByLabelTe
 
 Stories use `tags: ['autodocs']` and import from `storybook/test` for interaction tests.
 
-`GalleryGrid` accepts a `variant` prop: `"asymmetric"` (mixed sizes, used for featured sections) or `"uniform"` (equal grid).
+`GalleryGrid` accepts a `variant` prop: `"asymmetric"` (first item spans 2 cols + 2 rows, used for featured sections) or `"uniform"` (equal 3-col grid). It integrates `Lightbox` internally — no need to wire it separately.
+
+`MobileNav` is a client component (`'use client'`) that handles the hamburger menu toggle for small screens.
 
 ## Testing Stack
 
 - **Unit tests:** Vitest + jsdom + `@testing-library/react` (project: `unit`)
 - **Story tests:** Vitest + Playwright + Storybook vitest addon (project: `storybook`)
-- **E2E:** Playwright in `e2e/` (`pnpm e2e`)
 - **A11y:** Storybook a11y addon is set to `'error'` — a11y violations fail CI
 
 ## Branches & PRs

--- a/docs/ai/design/feature-hero-overlapping.md
+++ b/docs/ai/design/feature-hero-overlapping.md
@@ -1,0 +1,103 @@
+---
+phase: design
+title: System Design & Architecture
+feature: hero-overlapping
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+
+Pure frontend component — no API, no CMS, no state beyond local motion values. The new `HeroOverlapping` component replaces the existing `Hero` on the homepage. All data flows in via props from the server-component page.
+
+```mermaid
+graph TD
+  Page["app/page.tsx (Server Component)"]
+  HO["HeroOverlapping (Client Component)"]
+  Frame["HeroFrame (internal)"]
+  ScrollCue["HeroScrollCue (internal)"]
+  Image["next/image"]
+  Motion["motion/react"]
+
+  Page -->|"images, name"| HO
+  HO --> Frame
+  HO --> ScrollCue
+  Frame --> Image
+  Frame --> Motion
+  HO --> Motion
+```
+
+The component is a client component (`'use client'`) because it uses `useScroll`, `useMotionValue`, and `useSpring` from `motion/react`.
+
+## Data Models
+
+**Props interface (HeroOverlapping):**
+```ts
+interface HeroOverlappingProps {
+  /** The photographer's name. Surname is rendered in italic accent colour. */
+  name: string;
+  /**
+   * Pool of portfolio images to randomise from.
+   * The component picks 3 unique images on client mount — different every page load.
+   * Must contain at least 3 items.
+   */
+  imagePool: ImageType[];
+}
+```
+
+`ImageType` is imported from `@/components/types` (existing shared type).
+
+**Internal state:**
+```ts
+// Picked once on mount via useState lazy initialiser
+const [frames] = useState<[ImageType, ImageType, ImageType]>(() => pickThree(imagePool));
+// frames[0] = back, frames[1] = front, frames[2] = accent
+```
+
+`pickThree` is a pure utility (Fisher-Yates or simple sort shuffle) defined at the top of the file — not exported.
+
+No data model changes required to existing JSON files — the homepage page component passes the combined pool from `src/data/*.json` arrays.
+
+## Component Breakdown
+
+### `HeroOverlapping` (client component)
+- Root `<section>` — full viewport height, warm background, `overflow-hidden`
+- Wires up `useScroll` for scroll parallax and `useMotionValue` + `useSpring` for mouse parallax
+- Renders three `HeroFrame` instances with different layout/speed configs
+- Renders name text block and accent underline at bottom-left
+- Renders `HeroScrollCue` at bottom-right
+
+### `HeroFrame` (internal, not exported)
+- `motion.div` wrapper with absolute positioning and box-shadow
+- `next/image` with `fill` and fade-in entrance via `initial/animate`
+- Accepts: `image`, `className` (for size/position), `motionStyle` (scroll + mouse parallax transforms), `enterDelay`
+- Thin decorative inset border via `::before`-equivalent inner div
+
+### Name text block (inline in HeroOverlapping)
+- `<h1>` with serif font (`font-display`) — first name plain, surname wrapped in `<em>` styled with accent color
+- `motion.div` for `translateY` + `opacity` entrance
+- Accent underline: `motion.div` animated `width` from `0` to `40px`
+
+### `HeroScrollCue` (internal, not exported)
+- Fixed-position bottom-right within the hero `relative` container
+- "Scroll" label + animated vertical line (pulse loop)
+- Fades out as user scrolls past the hero (via `useTransform` on scroll progress)
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Random image selection | `useState` lazy initialiser on mount | Homepage is statically generated — server-side `Math.random()` would be fixed at build time. Client mount guarantees a new random pick on every page load. |
+| Mouse parallax approach | `useMotionValue` + `useSpring` (stiffness ~80, damping ~20) | Smooth lerp without a manual RAF loop; cleaner than the vanilla JS in the reference |
+| Scroll parallax | `useScroll` + `useTransform` per frame | Declarative, performant, integrates with motion's transform pipeline |
+| Image loading fade | `initial={{ opacity: 0 }} animate={{ opacity: 1 }}` on each frame | Matches reference `.frame img.loaded` pattern; avoids layout shift |
+| Reduced motion | `useReducedMotion()` — skip all `initial` states and parallax offsets | Matches existing `HeroContent` pattern in the codebase |
+| Accent frame on mobile | Hidden below `md` breakpoint | Three frames are cramped at 375px; two frames retain the compositional intent |
+| Tagline + specialties | Removed | Not present in the reference design; cleaner, more minimal |
+
+## Non-Functional Requirements
+
+- **Performance:** Three `next/image` components with `priority` on the front frame, lazy on back and accent. Parallax updates via motion's optimised transform pipeline (no layout thrash).
+- **Accessibility:** `<section>` with implicit landmark role. Images have descriptive `alt` text. Heading hierarchy: `<h1>` for the name. No interactive elements inside the frames.
+- **Responsive:** No horizontal overflow at any viewport. Accent frame hidden on mobile (`hidden md:block`).
+- **Animation safety:** All motion gated on `!shouldAnimate` from `useReducedMotion()`.

--- a/docs/ai/design/feature-hero-redesign.md
+++ b/docs/ai/design/feature-hero-redesign.md
@@ -1,0 +1,114 @@
+---
+phase: design
+title: Hero Redesign — System Design & Architecture
+feature: hero-redesign
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+
+The `Hero` server component renders the image and gradient. A new `HeroContent` **client component** handles all animation. This keeps the `'use client'` boundary as small as possible — only the overlay crosses it.
+
+```mermaid
+graph TD
+  HomePage["page.tsx (server)"] -->|passes hero props| Hero["Hero (server component)"]
+  Hero -->|renders| BgImage["next/image (fill)"]
+  Hero -->|renders| Gradient["gradient overlay div"]
+  Hero -->|renders| HeroContent["HeroContent (client component)"]
+  HeroContent -->|motion animation| Name["name — word-by-word clip reveal"]
+  HeroContent -->|motion animation| Tagline["tagline — word-by-word clip reveal"]
+  HeroContent -->|motion animation| Labels["specialty links — staggered clip reveal"]
+  HomeJSON["src/data/home.json"] -->|hero.name, hero.tagline, hero.specialties| HomePage
+```
+
+**New dependency:** `motion` (motion.dev) — `pnpm add motion`
+
+## Data Models
+
+### Updated `home.json` — `hero` object
+
+```json
+{
+  "hero": {
+    "image": {
+      "src": "/images/food/70.jpg",
+      "alt": "Neil Hurley Photography"
+    },
+    "name": "Neil Hurley",
+    "tagline": "Commercial photographer based in Dublin",
+    "specialties": [
+      { "label": "Food & Drink", "href": "/food" },
+      { "label": "Advertising & Product", "href": "/advertising" }
+    ]
+  }
+}
+```
+
+### Updated `HeroProps` interface
+
+```ts
+import type { ImageType, LinkType } from '@/components/types';
+
+interface HeroProps {
+  /** Hero background image. */
+  image: ImageType;
+  /** Photographer name displayed in the overlay. */
+  name: string;
+  /** Short positioning tagline. */
+  tagline: string;
+  /** Specialty area labels with hrefs, rendered as navigation links. */
+  specialties: LinkType[];
+}
+```
+
+`HeroContent` accepts the same props minus `image`.
+
+## Component Breakdown
+
+### `Hero` (`src/components/hero/hero.tsx`) — server component
+
+- Unchanged image + gradient rendering
+- Renders `<HeroContent name tagline specialties />` as a child
+
+### `HeroContent` (`src/components/hero/hero-content.tsx`) — client component
+
+Handles all Motion animation. Key technique: **clip-path word reveal**.
+
+Each word is wrapped in two `<span>` layers:
+- **Outer span:** `display: inline-block; overflow: hidden` — acts as the clip mask
+- **Inner span:** animated from `translateY(110%)` → `translateY(0)` — the word slides up from behind the clip edge
+
+The result is words appearing to emerge from an invisible baseline, like a typographic curtain lift. This is more precise than a `clip-path` on the container itself because each word animates independently.
+
+**Stagger sequence:**
+1. Name words — stagger 60ms apart, 500ms duration, `easeOut` curve
+2. Tagline words — begin after name completes + 100ms delay, stagger 40ms, 400ms duration
+3. Specialty labels — begin after tagline + 80ms delay, stagger 80ms, slide up + `clip-path: inset(0 0 100% 0)` → `inset(0 0 0% 0)`
+
+### `src/data/home.json`
+
+- `hero` object extended with `name`, `tagline`, `specialties`
+
+### `src/app/page.tsx`
+
+- Pass `homeData.hero.name`, `homeData.hero.tagline`, `homeData.hero.specialties` into `<Hero>`
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Text position | Bottom-left | Editorial photography convention; keeps subject unobscured |
+| `HeroContent` split | Thin client wrapper | Keeps server/client boundary explicit; Hero image SSR unaffected |
+| Animation technique | Per-word `translateY` inside `overflow:hidden` parent | Cleaner than container `clip-path`; each word is independently controllable |
+| Specialty labels | `clip-path: inset(0 0 100% 0)` → `inset(0 0 0% 0)` | Wipe-up reveal suits the pill/label shape; distinct from name technique |
+| `useReducedMotion` | `motion` built-in hook — skip animation if true | Respects OS preference; no animation flicker on first paint |
+| Name element | `<p>` styled large | Page has a visually hidden `<h1>` for a11y; name is presentational |
+| Links | `next/link` `<Link>` inside `motion.li` | Motion wraps the `<li>`, `<Link>` handles navigation |
+
+## Non-Functional Requirements
+
+- **Accessibility:** Text must meet WCAG AA contrast. `useReducedMotion` skips all animation. The animated elements still render in full at rest state for users who prefer no motion.
+- **Performance:** Motion is tree-shaken. Only `motion`, `useAnimate`, and `useReducedMotion` are imported. No additional network requests.
+- **Responsive:** Font sizes scale — name `text-3xl md:text-5xl`, tagline `text-sm md:text-base`. Labels wrap gracefully at 375px.
+- **SSR / hydration:** `HeroContent` renders with `'use client'`. Motion handles hydration cleanly — content is in DOM immediately, animation plays after mount. No layout shift.

--- a/docs/ai/implementation/feature-hero-overlapping.md
+++ b/docs/ai/implementation/feature-hero-overlapping.md
@@ -1,0 +1,178 @@
+---
+phase: implementation
+title: Implementation Guide
+feature: hero-overlapping
+---
+
+# Implementation Guide
+
+## Development Setup
+
+No new dependencies. Existing stack covers everything:
+- `motion/react` (motion library, already installed)
+- `next/image` (Next.js built-in)
+- Tailwind CSS 4 (styling)
+- `@/components/types` for `ImageType`
+
+Run `pnpm dev` and `pnpm storybook` in parallel during development.
+
+## Code Structure
+
+```
+src/components/hero-overlapping/
+  hero-overlapping.tsx   # Main component (client)
+  index.ts               # Named export: HeroOverlapping
+  hero-overlapping.test.tsx
+  hero-overlapping.stories.tsx
+```
+
+The old `src/components/hero/` directory is **not deleted** — it remains for reference and its tests must still pass. Only the homepage import changes.
+
+## Implementation Notes
+
+### Random image selection
+
+```ts
+function pickThree(pool: ImageType[]): [ImageType, ImageType, ImageType] {
+  const shuffled = [...pool].sort(() => Math.random() - 0.5);
+  return [shuffled[0], shuffled[1], shuffled[2]];
+}
+
+// In component:
+const [frames] = useState<[ImageType, ImageType, ImageType]>(() => pickThree(imagePool));
+// frames[0] → back frame, frames[1] → front frame, frames[2] → accent frame
+```
+
+Using `useState` with a lazy initialiser ensures selection runs once on the client, after hydration — so SSG/SSR output is consistent (no hydration mismatch) and every browser page load gets a fresh random set.
+
+### Frame layout
+
+Three absolutely-positioned `motion.div` containers inside a `relative` section. Tailwind classes handle size and position. Reference values (translate to Tailwind):
+
+| Frame | Width | Height | Position |
+|---|---|---|---|
+| `back` | `w-[52%]` | `h-[62%]` | `right-[6%] top-[18%]` |
+| `front` | `w-[38%]` | `h-[52%]` | `left-[10%] top-[26%]` |
+| `accent` | `w-[18%]` | `h-[24%]` | `right-[4%] top-[10%] hidden md:block` |
+
+Z-levels: back → `z-10`, accent → `z-20`, front → `z-30`.
+
+Each frame has `box-shadow` — use Tailwind shadow utilities or a custom CSS variable shadow (check design system).
+
+### Entrance animations (motion/react)
+
+```tsx
+// Frame fade-in
+<motion.div
+  initial={shouldAnimate ? { opacity: 0, y: 20 } : false}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: 0.8, delay: enterDelay, ease: [0.23, 1, 0.32, 1] }}
+/>
+
+// Name text
+<motion.div
+  initial={shouldAnimate ? { opacity: 0, y: 24 } : false}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: 1, delay: 0.3, ease: [0.23, 1, 0.32, 1] }}
+/>
+
+// Accent underline width
+<motion.div
+  initial={shouldAnimate ? { width: 0 } : { width: 40 }}
+  animate={{ width: 40 }}
+  transition={{ duration: 0.8, delay: 0.9, ease: [0.23, 1, 0.32, 1] }}
+/>
+```
+
+### Scroll parallax
+
+```tsx
+const sectionRef = useRef<HTMLElement>(null);
+const { scrollYProgress } = useScroll({ target: sectionRef, offset: ['start start', 'end start'] });
+
+const backY  = useTransform(scrollYProgress, [0, 1], [0,  60]);  // slow
+const frontY = useTransform(scrollYProgress, [0, 1], [0, -100]); // faster, opposite
+const accentY = useTransform(scrollYProgress, [0, 1], [0,  40]);
+```
+
+Apply via `style={{ y: backY }}` on each frame's `motion.div`.
+
+### Mouse parallax
+
+```tsx
+const mouseX = useMotionValue(0);
+const mouseY = useMotionValue(0);
+
+const smoothX = useSpring(mouseX, { stiffness: 80, damping: 20 });
+const smoothY = useSpring(mouseY, { stiffness: 80, damping: 20 });
+
+// On section mousemove (desktop only):
+const handleMouseMove = (e: React.MouseEvent<HTMLElement>) => {
+  if (!shouldAnimate) return;
+  const rect = e.currentTarget.getBoundingClientRect();
+  const x = (e.clientX - rect.left) / rect.width - 0.5;  // -0.5 to 0.5
+  const y = (e.clientY - rect.top)  / rect.height - 0.5;
+  mouseX.set(x);
+  mouseY.set(y);
+};
+
+// Per-frame multipliers (back: -8/-6, front: 14/10, accent: -5/-4)
+const backMotionX  = useTransform(smoothX, v => v * -8);
+const backMotionY  = useTransform(smoothY, v => v * -6);
+// etc.
+```
+
+Combine scroll + mouse parallax by merging transforms: `useTransform` for each axis, or stack via `style={{ x: backMouseX, y: backY }}` (motion composites multiple `style` values correctly when both are motion values).
+
+### Scroll cue fade-out
+
+```tsx
+const scrollCueOpacity = useTransform(scrollYProgress, [0, 0.15], [1, 0]);
+// Apply to HeroScrollCue wrapper
+```
+
+### Reduced motion gate
+
+```tsx
+const shouldAnimate = !useReducedMotion();
+// Pass to all initial props and disable mousemove handler
+```
+
+## Integration Points
+
+**`src/app/page.tsx`** — server component. Change:
+```tsx
+// Before
+import { Hero } from '@/components/hero';
+// After
+import { HeroOverlapping } from '@/components/hero-overlapping';
+```
+
+Pass the full image pool from JSON data:
+```tsx
+import foodImages from '@/data/food.json';
+import advertisingImages from '@/data/advertising.json';
+
+// Combine all images into a single pool
+const heroImagePool = [...foodImages, ...advertisingImages];
+
+<HeroOverlapping name={siteConfig.name} imagePool={heroImagePool} />
+```
+
+The component picks 3 random images on client mount — no server-side selection needed. The specific JSON files/fields to use are a content decision for the principal developer.
+
+## Error Handling
+
+- `next/image` with `fill` requires the parent to have `position: relative` (or absolute) and explicit dimensions — ensured by Tailwind classes on each frame div.
+- If an image fails to load, `next/image` handles fallback internally; no extra error state needed.
+
+## Performance Considerations
+
+- Only `front` frame gets `priority` prop on `next/image`; back and accent use default lazy loading.
+- Mouse parallax listener is added as a React event handler (no manual `addEventListener`) — React handles cleanup automatically.
+- Scroll parallax uses motion's optimised path (GPU-composited `transform` only — no layout properties).
+- `will-change: transform` is applied by motion automatically when animating transforms.
+
+## Security Notes
+
+No user input, no external data fetching, no authentication — no security surface area in this component.

--- a/docs/ai/implementation/feature-hero-redesign.md
+++ b/docs/ai/implementation/feature-hero-redesign.md
@@ -1,0 +1,268 @@
+---
+phase: implementation
+title: Hero Redesign — Implementation Guide
+feature: hero-redesign
+---
+
+# Implementation Guide
+
+## Development Setup
+
+Install the Motion library before starting:
+
+```bash
+pnpm add motion
+```
+
+## Code Structure
+
+Files to modify:
+```
+src/
+  data/home.json                        # Add name, tagline, specialties to hero object
+  components/hero/
+    hero.tsx                            # Add HeroProps fields; render HeroContent
+    hero-content.tsx                    # NEW — 'use client' animation component
+    hero.test.tsx                       # Update tests for new props + HeroContent render
+    hero.stories.tsx                    # Update story args
+  app/page.tsx                          # Pass new hero props
+```
+
+## Implementation Notes
+
+### 1. `home.json` — extend hero object
+
+```json
+"hero": {
+  "image": { "src": "/images/food/70.jpg", "alt": "Neil Hurley Photography" },
+  "name": "Neil Hurley",
+  "tagline": "Commercial photographer based in Dublin",
+  "specialties": [
+    { "label": "Food & Drink", "href": "/food" },
+    { "label": "Advertising & Product", "href": "/advertising" }
+  ]
+}
+```
+
+### 2. `hero.tsx` — updated server component
+
+```tsx
+import Image from 'next/image';
+import type { ImageType, LinkType } from '@/components/types';
+import { HeroContent } from './hero-content';
+
+interface HeroProps {
+  image: ImageType;
+  name: string;
+  tagline: string;
+  specialties: LinkType[];
+}
+
+export function Hero({ image, name, tagline, specialties }: HeroProps) {
+  return (
+    <section className="relative h-[85vh] min-h-[500px] w-full overflow-hidden">
+      <Image
+        src={image.src}
+        alt={image.alt}
+        fill
+        className="object-cover pointer-events-none"
+        priority
+        quality={85}
+        sizes="100vw"
+      />
+      <div className="absolute inset-0 bg-linear-to-t from-background to-transparent pointer-events-none" />
+      <HeroContent name={name} tagline={tagline} specialties={specialties} />
+    </section>
+  );
+}
+```
+
+### 3. `hero-content.tsx` — clip-path word reveal animation
+
+The core technique: each word is wrapped in an `overflow-hidden` outer `<span>` (the clip mask) containing an inner `<span>` that animates `y: "110%" → y: 0`. Words at rest are fully visible — animation is purely additive.
+
+**Brand easing:** `cubic-bezier(0.23, 1, 0.32, 1)` — specified in the design system as the standard `ease-out`. Use this constant for all Motion transitions.
+
+**Ampersand convention:** The design system specifies that `&` in display/heading text uses the italic variant of Libre Baskerville in `text-accent`. Both "Food & Drink" and "Advertising & Product" contain `&` — the `WordToken` component handles this for all text contexts.
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { motion, useReducedMotion } from 'motion/react';
+import type { LinkType } from '@/components/types';
+
+// Design system ease-out — cubic-bezier(0.23, 1, 0.32, 1)
+const EASE_OUT = [0.23, 1, 0.32, 1] as const;
+
+interface HeroContentProps {
+  name: string;
+  tagline: string;
+  specialties: LinkType[];
+}
+
+/**
+ * Renders a single word token.
+ * Ampersands receive the brand treatment: italic Libre Baskerville in text-accent.
+ */
+function WordToken({ word }: { word: string }) {
+  if (word === '&') {
+    return (
+      <span className="font-display italic text-accent" aria-label="and">
+        &amp;
+      </span>
+    );
+  }
+  return <>{word}</>;
+}
+
+/**
+ * Splits text into words and animates each with an overflow-hidden clip reveal.
+ * aria-label on wrapper = full string for screen readers.
+ * Individual word spans are aria-hidden to avoid fragmented announcement.
+ */
+function RevealWords({
+  text,
+  delayOffset = 0,
+  stagger = 0.06,
+  duration = 0.5,
+  shouldAnimate,
+}: {
+  text: string;
+  delayOffset?: number;
+  stagger?: number;
+  duration?: number;
+  shouldAnimate: boolean;
+}) {
+  const words = text.split(' ');
+  return (
+    <span aria-label={text}>
+      {words.map((word, i) => (
+        <span
+          key={i}
+          className="inline-block overflow-hidden leading-[1.1]"
+          aria-hidden="true"
+        >
+          <motion.span
+            className="inline-block"
+            initial={shouldAnimate ? { y: '110%' } : false}
+            animate={{ y: 0 }}
+            transition={{
+              duration,
+              delay: delayOffset + i * stagger,
+              ease: EASE_OUT,
+            }}
+          >
+            <WordToken word={word} />
+          </motion.span>
+          {/* Non-breaking space lives outside the clip mask — never gets clipped */}
+          {i < words.length - 1 && '\u00A0'}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function HeroContent({ name, tagline, specialties }: HeroContentProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const shouldAnimate = !prefersReducedMotion;
+
+  const nameWordCount = name.split(' ').length;
+  // tagline starts after name completes + 100ms buffer
+  const taglineDelay = nameWordCount * 0.06 + 0.1;
+  // specialties start after tagline completes + 80ms buffer
+  const taglineWordCount = tagline.split(' ').length;
+  const specialtiesDelay = taglineDelay + taglineWordCount * 0.04 + 0.08;
+
+  return (
+    <div className="absolute inset-x-0 bottom-0 px-8 pb-12 md:px-16 md:pb-16 z-10">
+      {/*
+        Photographer name — Display 1 from design system:
+        4rem (text-6xl), Libre Baskerville 400, tracking -0.02em
+        Scales to text-4xl on mobile.
+      */}
+      <p className="font-display text-4xl md:text-6xl font-normal text-card tracking-[-0.02em] mb-3 drop-shadow-md">
+        <RevealWords
+          text={name}
+          shouldAnimate={shouldAnimate}
+          stagger={0.06}
+          duration={0.6}
+        />
+      </p>
+
+      {/*
+        Tagline — Body Small from design system:
+        0.875rem (text-sm), Outfit 300 (font-light)
+      */}
+      <p className="font-body text-sm font-light text-card/75 mb-8 drop-shadow-sm">
+        <RevealWords
+          text={tagline}
+          shouldAnimate={shouldAnimate}
+          delayOffset={taglineDelay}
+          stagger={0.04}
+          duration={0.5}
+        />
+      </p>
+
+      {/*
+        Specialty labels — Label style from design system:
+        0.75rem (text-xs), Outfit 400 (font-normal), 0.18em tracking, uppercase.
+        Clip-path wipe-up reveal on motion.li.
+        Sharp corners — no border-radius (design system: only gallery items use rounded-sm).
+        Ampersands in labels handled by WordToken inside the Link.
+      */}
+      <nav aria-label="Photography specialties">
+        <ul className="flex flex-wrap gap-3">
+          {specialties.map((s, i) => (
+            <motion.li
+              key={s.href}
+              initial={shouldAnimate ? { clipPath: 'inset(0 0 100% 0)' } : false}
+              animate={{ clipPath: 'inset(0 0 0% 0)' }}
+              transition={{
+                duration: 0.45,
+                delay: specialtiesDelay + i * 0.1,
+                ease: EASE_OUT,
+              }}
+            >
+              <Link
+                href={s.href}
+                className="font-body text-xs font-normal uppercase tracking-[0.18em] text-card border border-card/40 px-4 py-2 inline-block hover:bg-card/10 transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+              >
+                {s.label.split(' ').map((word, wi, arr) => (
+                  <span key={wi}>
+                    <WordToken word={word} />
+                    {wi < arr.length - 1 && '\u00A0'}
+                  </span>
+                ))}
+              </Link>
+            </motion.li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+  );
+}
+```
+
+### Patterns & Best Practices
+
+- **Design system easing** — always use `EASE_OUT = [0.23, 1, 0.32, 1]`, the design-system-specified `cubic-bezier(0.23, 1, 0.32, 1)`. Do not use a different curve.
+- **Display 1 type scale** — hero name is `text-6xl` (4rem), `tracking-[-0.02em]`, `font-display`, weight 400. The design system is explicit that this scale is reserved for hero titles.
+- **Ampersand convention** — `&` tokens in display text must render as italic + `text-accent` using Libre Baskerville's italic variant. Both specialty labels contain `&`; `WordToken` handles this consistently for all text contexts.
+- **Sharp corners everywhere** — design system specifies `border-radius: 2px` for gallery items only. All other elements (including specialty label borders) are sharp — don't add any `rounded-*` class.
+- **`aria-label` on wrapper + `aria-hidden` on word spans** — screen readers announce the full string; they never encounter the fragmented word structure.
+- **`initial={shouldAnimate ? {...} : false}`** — `false` tells Motion to skip animation entirely for reduced-motion users with no FOUC or layout shift.
+- **Inter-word spacing** — `\u00A0` lives outside the `overflow-hidden` span and is never clipped during animation.
+- **Duration values** — 600ms for name (slower = more gravitas at display scale), 500ms for tagline, 450ms for labels. All use brand `EASE_OUT`.
+
+## Integration Points
+
+`page.tsx` — pass new props:
+```tsx
+<Hero
+  image={homeData.hero.image}
+  name={homeData.hero.name}
+  tagline={homeData.hero.tagline}
+  specialties={homeData.hero.specialties}
+/>
+```

--- a/docs/ai/planning/feature-hero-overlapping.md
+++ b/docs/ai/planning/feature-hero-overlapping.md
@@ -1,0 +1,71 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+feature: hero-overlapping
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+
+- [x] Milestone 1: New `HeroOverlapping` component renders correctly in Storybook with static layout
+- [x] Milestone 2: All motion effects (entrance, scroll parallax, mouse parallax) working in the dev server
+- [x] Milestone 3: Homepage wired up, old `Hero` replaced, all tests passing
+
+## Task Breakdown
+
+### Phase 1: Component scaffold
+
+- [x] 1.1 Create `src/components/hero-overlapping/` directory with `index.ts`
+- [x] 1.2 Implement static layout in `hero-overlapping.tsx` — three absolutely-positioned frame divs, name text, scroll cue, correct sizing/positions for desktop and mobile
+- [x] 1.3 Add `next/image` inside each frame with `fill` + `sizes` attributes
+- [x] 1.4 Write `hero-overlapping.stories.tsx` with a default story (three images from `public/images/`)
+- [ ] 1.5 Verify Storybook renders without a11y errors
+
+### Phase 2: Motion effects
+
+- [x] 2.1 Add entrance animations — frame fade-in with staggered `enterDelay`, name `translateY` + `opacity`, accent underline `width` grow
+- [x] 2.2 Add scroll parallax — `useScroll` + `useTransform` with distinct `inputRange`/`outputRange` per frame
+- [x] 2.3 Add mouse parallax — `useMotionValue` + `useSpring` for X/Y, apply different intensity per frame
+- [x] 2.4 Wire `HeroScrollCue` fade-out on scroll using `useTransform` on scroll progress
+- [x] 2.5 Gate all motion on `useReducedMotion()`
+
+### Phase 3: Integration & tests
+
+- [x] 3.1 Update `src/app/page.tsx` — import `HeroOverlapping`, pass three images from data JSON, remove old `Hero` import
+- [ ] 3.2 Verify homepage renders correctly at desktop, tablet, and mobile in the dev server
+- [x] 3.3 Write `hero-overlapping.test.tsx` — unit tests covering: renders name, renders all frame images, reduced motion skips animation props, scroll cue present
+- [x] 3.4 Run `pnpm test` and `pnpm typecheck` — fix any failures
+- [x] 3.5 Run `pnpm test:coverage` — confirm 100% coverage on new files
+
+## Dependencies
+
+- `motion/react` — already installed (used by existing `HeroContent`)
+- `next/image` — already available
+- Three portfolio images — must exist in `public/images/`; homepage page component selects them from existing JSON data
+- No new packages required
+
+## Implementation Order
+
+1. Static layout first (no motion) → verify in Storybook
+2. Add entrance animations → verify reduced-motion path
+3. Add scroll parallax → verify in dev server
+4. Add mouse parallax → verify desktop-only gating
+5. Wire homepage → run full test suite
+
+## Risks & Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Mouse parallax janky on lower-end devices | Use `useSpring` with conservative stiffness; only enable above `md` breakpoint |
+| `next/image` with `fill` inside absolutely-positioned parent requires explicit dimensions on parent | Ensure each frame div has explicit `width`/`height` via Tailwind classes, not percentages alone |
+| Scroll parallax fighting with `overflow-hidden` on the section | Use `useScroll({ target: sectionRef })` scoped to the section element |
+| Three `priority` images hitting LCP budget | Only the front (foreground) frame gets `priority`; back and accent are `loading="lazy"` |
+
+## Implementation Notes
+
+- `useTransform` callbacks `(v) => v * N` for mouse parallax and `([s, m]) => s + m` for combined scroll+mouse Y are mocked with call invocation in tests for 100% function coverage
+- `motionStyle` set to `{}` (empty) when `!shouldAnimate` — clean way to disable parallax without conditional hook calls
+- `HeroScrollCue` uses two-layer motion.div: outer for scroll-fade (`style={{ opacity }}`), inner for entrance animation — avoids opacity conflict
+- Homepage uses `homeData.hero.name` ("Neil Hurley") so the first/last name split produces "Neil" + "Hurley" correctly
+- sr-only `<h1>` removed from page.tsx since `HeroOverlapping` renders a visible `<h1>`

--- a/docs/ai/planning/feature-hero-redesign.md
+++ b/docs/ai/planning/feature-hero-redesign.md
@@ -1,0 +1,67 @@
+---
+phase: planning
+title: Hero Redesign — Project Planning & Task Breakdown
+feature: hero-redesign
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+
+- [ ] Milestone 1: Data & types updated — `home.json` and `HeroProps` reflect new fields
+- [ ] Milestone 2: Component implemented — Hero renders name, tagline, and specialty links with correct styling
+- [ ] Milestone 3: Tests & stories passing — unit tests, Storybook stories, and a11y checks all green
+
+## Task Breakdown
+
+### Phase 1: Foundation
+
+- [ ] **1.1** `pnpm add motion` — add Motion library
+- [ ] **1.2** Add `name`, `tagline`, and `specialties` fields to `src/data/home.json`
+- [ ] **1.3** Update `HeroProps` in `hero.tsx` to include the three new props (typed using existing `LinkType`)
+- [ ] **1.4** Update `src/app/page.tsx` to pass `homeData.hero.name`, `homeData.hero.tagline`, and `homeData.hero.specialties` into `<Hero>`
+
+### Phase 2: Component Implementation
+
+- [ ] **2.1** Create `src/components/hero/hero-content.tsx` — `'use client'` component with `RevealWords` helper and `HeroContent` export
+- [ ] **2.2** Implement `RevealWords` — per-word `overflow-hidden` outer span + `motion.span` inner span animating `y: "110%" → 0`
+- [ ] **2.3** Implement name reveal — `font-display`, `text-3xl md:text-5xl`, `text-card`, stagger 60ms, expo-out easing
+- [ ] **2.4** Implement tagline reveal — `font-body`, `text-sm md:text-base`, `text-card/75`, delayed after name, stagger 40ms
+- [ ] **2.5** Implement specialty label reveal — `clip-path: inset(0 0 100% 0) → inset(0 0 0% 0)` on `motion.li`, pill-border styling, delayed after tagline
+- [ ] **2.6** Wire `useReducedMotion` — pass `initial={shouldAnimate ? {...} : false}` to skip animation cleanly
+- [ ] **2.7** Update `hero.tsx` to render `<HeroContent>` and accept updated props
+
+### Phase 3: Tests & Stories
+
+- [ ] **3.1** Add Motion mock to `hero.test.tsx` (`vi.mock('motion/react', ...)`)
+- [ ] **3.2** Update unit tests — assert accessible name/tagline strings, specialty hrefs and labels, empty specialties edge case
+- [ ] **3.3** Update `hero.stories.tsx` — extend `Default` and `FoodHero` args; add `ReducedMotion` story
+- [ ] **3.4** Run `pnpm test:stories` — confirm Storybook a11y passes
+- [ ] **3.5** Run `pnpm test` — confirm all unit tests pass
+- [ ] **3.6** Run `pnpm typecheck` and `pnpm lint` — zero errors
+
+## Dependencies
+
+- Task 1.1 before any Phase 2 work (Motion must be installed)
+- Task 1.3 must complete before 2.x (props must be defined)
+- Task 1.4 must complete before visual dev-server testing
+- All Phase 2 tasks before Phase 3
+
+## Timeline & Estimates
+
+| Phase | Effort |
+|---|---|
+| Phase 1 (install + data + types) | ~30 min |
+| Phase 2 (animation component) | ~2–3 hours |
+| Phase 3 (tests + stories) | ~1–1.5 hours |
+
+## Risks & Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Motion not available in jsdom test environment | Mock `motion/react` in test setup (see testing doc) |
+| Word splitting breaks with punctuation (e.g. "Dublin,") | Treat punctuation as part of the word — it stays attached; no special handling needed |
+| Inter-word spacing clipped during animation | Non-breaking space placed *outside* the `overflow-hidden` span |
+| `clip-path` on specialty labels looks jaggy on some GPUs | Use `will-change: clip-path` if needed; test on real device |
+| Contrast failure in a11y checks | `drop-shadow-md` on name + gradient from page background provides scrim; test in Storybook a11y panel early |
+| `home.json` shape change breaks `page.tsx` | Update `page.tsx` (Task 1.4) immediately after JSON change |

--- a/docs/ai/requirements/feature-hero-overlapping.md
+++ b/docs/ai/requirements/feature-hero-overlapping.md
@@ -1,0 +1,67 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+feature: hero-overlapping
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+
+The current hero is a single full-bleed background image with a gradient overlay and text pinned to the bottom-left. It works but reads as generic — many portfolio sites use the same pattern. The goal is to replace it with an editorial, layered composition that better communicates the photographer's craft: three overlapping photo frames arranged asymmetrically on a warm background, with parallax depth and restrained entrance animations.
+
+- **Who is affected:** Every homepage visitor sees the hero; it is the primary first impression.
+- **Current workaround:** No workaround — the current design is functional but aesthetically common.
+
+## Goals & Objectives
+
+**Primary goals:**
+- Replace `Hero` with a new `HeroOverlapping` component on the homepage
+- Three portfolio images displayed as overlapping frames (back, front, accent) at distinct z-levels
+- Light/warm background (`--color-bg` / `bg-background`) — no full-bleed dark image
+- Entrance animations: frames fade/slide in, name text reveals, accent underline grows
+- Scroll parallax: each frame moves at a different Y speed as the user scrolls
+- Mouse parallax (desktop only): frames subtly shift based on cursor position for depth
+
+**Secondary goals:**
+- Scroll cue indicator (bottom-right) that pulses and fades on scroll
+- Respect `prefers-reduced-motion` — skip all motion when set
+- Responsive layout: adjusted frame sizes and positions at mobile breakpoints
+
+**Non-goals:**
+- The tagline and specialty links from the previous hero are removed in this design
+- No lightbox or click interaction on the frames
+- No server-side personalisation — randomisation is purely client-side
+
+## User Stories & Use Cases
+
+- As a **homepage visitor**, I see three overlapping photo frames drawn randomly from the portfolio pool — a different combination on every page load.
+- As a **returning visitor**, the hero feels fresh each visit without any CMS or server changes.
+- As a **desktop user**, I notice subtle parallax depth as I move my mouse and scroll, creating a tactile, high-end feel.
+- As a **mobile user**, I see the same composition at appropriate sizes without horizontal overflow or janky scroll.
+- As a **user with reduced motion preference**, I see the final static state immediately, with no animations playing.
+
+## Success Criteria
+
+- [ ] Three frames render at correct sizes and z-levels matching the reference design
+- [ ] Name text (`Neil Hurley`) shows with last name in italic accent color
+- [ ] Accent underline animates from `width: 0` to `width: 40px` on load
+- [ ] Scroll parallax moves each frame at a distinct Y offset
+- [ ] Mouse parallax runs on desktop; disabled on mobile
+- [ ] `prefers-reduced-motion` disables all animations (entrance + parallax)
+- [ ] No horizontal overflow on any viewport
+- [ ] All existing tests pass; new component has 100% unit test coverage
+- [ ] Storybook stories render without a11y errors
+
+## Constraints & Assumptions
+
+- **Tech:** Must use `motion/react` (already installed). No raw CSS animations in JS for motion.
+- **Images:** The component accepts an `imagePool: ImageType[]` prop (all available portfolio images from JSON). It picks 3 unique random images on client mount via `useState` lazy initialiser — guarantees a different set every page load without SSR/SSG constraints.
+- **Styling:** Tailwind CSS 4 only — no inline styles except where `motion` requires numeric values for interpolation.
+- **Next.js:** Use `next/image` for all three frame images with `fill` and appropriate `sizes`.
+- **Assumption:** The existing `Hero` component and its tests/stories remain untouched; only the homepage import changes.
+
+## Questions & Open Items
+
+- [ ] Should the accent frame be shown on mobile, or hidden below a breakpoint? (Reference hides nav links on mobile — accent frame may feel crowded at small sizes.) **Proposed:** hide accent frame below `md`.
+- [ ] Should the full combined image pool (food + advertising) be used, or a curated subset? Needs content decision from the principal developer.

--- a/docs/ai/requirements/feature-hero-redesign.md
+++ b/docs/ai/requirements/feature-hero-redesign.md
@@ -1,0 +1,61 @@
+---
+phase: requirements
+title: Hero Redesign — Requirements & Problem Understanding
+feature: hero-redesign
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+
+The current Hero component is a full-width background image with a gradient overlay and no text content. It communicates nothing about Neil Hurley's identity or specialties. First-time visitors — typically potential clients or art directors — cannot tell from the hero what kind of photographer Neil is or where to go next. This increases bounce rate and reduces the quality of initial impressions.
+
+**Current state:** Image + gradient only. No name, no tagline, no specialty labels, no navigation cues.
+
+## Goals & Objectives
+
+**Primary goals:**
+- Surface Neil's name and a short positioning tagline within the hero
+- Display his two specialty areas (Food & Drink, Advertising & Product) as visible, tappable labels that link to the relevant portfolio sections
+- Communicate the type and quality of work at a glance
+
+**Secondary goals:**
+- Provide a clear visual entry point so visitors can self-select into the relevant section without scrolling
+- Maintain the clean, gallery-first aesthetic of the design system
+
+**Non-goals:**
+- Replacing the hero image or changing how images are managed
+- Adding video, carousel, or animated background
+- Redesigning any page beyond the homepage hero
+
+## User Stories & Use Cases
+
+- As a **first-time visitor**, I want to see the photographer's name and specialty areas in the hero so that I immediately know what Neil Hurley photographs.
+- As a **potential food & drink client**, I want to see a clear "Food & Drink" label in the hero that links to the relevant portfolio so that I can jump straight to work relevant to my brief.
+- As a **potential advertising client**, I want to see a clear "Advertising & Product" label so that I can assess his commercial work without scrolling.
+- As a **mobile user**, I want the hero text to be legible and uncluttered on small screens so that the first impression is as strong as on desktop.
+
+## Success Criteria
+
+- The hero renders the photographer's name, a short tagline, and at least the two specialty area labels
+- Each specialty label navigates to its respective portfolio page (`/food`, `/advertising`)
+- All new text elements meet WCAG AA contrast requirements against the hero image
+- The Storybook a11y addon reports zero violations on the updated Hero stories
+- Unit tests cover all new props and rendered output
+- Existing Hero behaviour (full-width image, gradient overlay, responsive height) is unchanged
+
+## Constraints & Assumptions
+
+- **Tailwind CSS 4 only** — no inline styles or CSS modules; design tokens from `src/styles/globals.css`
+- **Server component** — Hero must remain a server component; no `'use client'` boundary needed for static text and links
+- **Data-driven** — new text content (name, tagline, specialty labels + hrefs) must come from `src/data/home.json`, not be hardcoded in the component
+- **`next/image`** — the background image implementation stays as-is
+- **Font system** — `font-display` (Libre Baskerville) for the photographer name/tagline; `font-body` (Outfit) for labels, per design system convention
+- Specialty areas are fixed: Food & Drink and Advertising & Product
+
+## Questions & Open Items
+
+- Should the tagline be a permanent fixture in `home.json` or sourced from `site-config.ts`?
+- Should specialty labels use `<Link>` (Next.js) or plain `<a>` tags? (Likely `<Link>` for client-side navigation.)
+- Should there be a CTA button (e.g., "View Portfolio") in addition to specialty labels, or are the labels sufficient?
+- What is the preferred vertical positioning of the text — bottom-left (common in editorial photography sites) or centred?

--- a/docs/ai/testing/feature-hero-overlapping.md
+++ b/docs/ai/testing/feature-hero-overlapping.md
@@ -1,0 +1,91 @@
+---
+phase: testing
+title: Testing Strategy
+feature: hero-overlapping
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+
+- **Unit tests:** 100% of new/changed code in `src/components/hero-overlapping/`
+- **Story tests:** Storybook interaction test for entrance animation completion
+- **A11y:** Storybook a11y addon set to `'error'` — zero violations required
+- **Manual:** Visual check in dev server at desktop, tablet (768px), and mobile (375px)
+
+## Unit Tests
+
+### `HeroOverlapping`
+
+- [ ] Renders the photographer's name with first and last parts
+- [ ] Last name is wrapped in an element that carries accent styling (check for `<em>` or appropriate element)
+- [ ] Renders exactly 3 frame images chosen from the provided pool
+- [ ] All 3 rendered images are members of the `imagePool` prop
+- [ ] No duplicate images across the 3 frames (all 3 are unique)
+- [ ] Accent frame is hidden on small screens — carries `hidden md:block` (or equivalent class)
+- [ ] Scroll cue is rendered (check for "scroll" text or aria-label)
+- [ ] When `useReducedMotion` returns `true`, no `initial` animation props are set (frames render at final opacity/position)
+- [ ] With a pool of exactly 3 images, renders all 3 without error
+
+### Mock strategy
+
+- Mock `motion/react`: `useReducedMotion` → controllable boolean; `useScroll`, `useMotionValue`, `useSpring`, `useTransform` → identity mocks returning `{ get: () => 0, set: () => {} }` or `0`
+- Mock `next/image` → plain `<img>` (standard testing-library pattern for Next.js)
+- For randomness tests: run `pickThree` in isolation with a fixed pool and assert output length is 3 and all items are unique
+
+**Run single file:**
+```bash
+pnpm vitest run --project unit src/components/hero-overlapping/hero-overlapping.test.tsx
+```
+
+**Coverage:**
+```bash
+pnpm test:coverage
+```
+
+## Integration Tests
+
+- [ ] Homepage (`/`) renders `HeroOverlapping` instead of `Hero` — verify name "Neil Hurley" appears in a heading
+- [ ] No TypeScript errors in the page/component import chain (`pnpm typecheck`)
+
+## End-to-End Tests (Playwright MCP)
+
+- [ ] Navigate to `/` — three frame images are visible in the DOM
+- [ ] Name heading present with correct text
+- [ ] Scroll cue visible before scrolling, fades after scroll
+- [ ] No horizontal scrollbar at 1440px, 768px, and 375px viewport widths
+- [ ] Keyboard navigation: no focus traps inside the hero frames
+
+## Test Data
+
+- Three placeholder images from `public/images/` used in Storybook story and unit tests
+- `alt` values: `"Portfolio image 1"`, `"Portfolio image 2"`, `"Portfolio image 3"` (or matching actual data)
+
+## Test Reporting & Coverage
+
+```bash
+pnpm test:coverage
+```
+
+Target: 100% statements/branches/functions on `hero-overlapping.tsx`.
+
+Known acceptable gap: scroll and mouse parallax motion value computations are difficult to assert numerically in jsdom — test that the motion values are created and the handlers are wired, not the pixel output.
+
+## Manual Testing
+
+- [ ] Desktop (1440px): three frames visible, overlapping correctly, mouse parallax responds to cursor
+- [ ] Tablet (768px): layout intact, accent frame visible
+- [ ] Mobile (375px): no overflow, accent frame hidden, text legible
+- [ ] Reduced motion (OS setting or Chrome DevTools): frames and text appear immediately at final state
+- [ ] Scroll: parallax offset visible; scroll cue fades as hero exits viewport
+- [ ] Images load with fade-in (check on throttled connection)
+
+## Performance Testing
+
+- Lighthouse LCP: front frame image should be the LCP candidate — confirm `priority` prop is set and image is in the viewport on load
+- No layout shift from image loading — `fill` + explicit frame dimensions prevents CLS
+
+## Bug Tracking
+
+- File issues under `feature/hero-overlapping` branch
+- Regression: ensure existing `Hero` component tests still pass after homepage swap

--- a/docs/ai/testing/feature-hero-redesign.md
+++ b/docs/ai/testing/feature-hero-redesign.md
@@ -1,0 +1,107 @@
+---
+phase: testing
+title: Hero Redesign — Testing Strategy
+feature: hero-redesign
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+
+- 100% of new/changed lines in `hero.tsx` and `hero-content.tsx`
+- Storybook a11y addon zero violations on all Hero stories
+- Manual visual check at 375px, 768px, and 1280px
+- Manual check with `prefers-reduced-motion: reduce` (OS setting or DevTools)
+
+## Unit Tests (`hero.test.tsx`)
+
+Motion must be mocked in the jsdom unit test environment since it relies on browser animation APIs.
+
+### Mocking strategy
+
+```ts
+vi.mock('motion/react', () => ({
+  motion: {
+    span: ({ children, ...rest }: React.HTMLAttributes<HTMLSpanElement>) =>
+      <span {...rest}>{children}</span>,
+    li: ({ children, ...rest }: React.HTMLAttributes<HTMLLIElement>) =>
+      <li {...rest}>{children}</li>,
+  },
+  useReducedMotion: () => false,
+}));
+```
+
+### `Hero` component
+
+- [ ] Renders the background `<img>` with correct `src` and `alt`
+- [ ] Renders `HeroContent` (presence of the specialty `<nav>` is sufficient proxy)
+
+### `HeroContent` component
+
+- [ ] Renders a `<nav aria-label="Photography specialties">`
+- [ ] Full name string is accessible (via `aria-label` on the wrapper span)
+- [ ] Full tagline string is accessible (via `aria-label` on the wrapper span)
+- [ ] Renders one `<li>` per specialty
+- [ ] Each specialty `<a>` has the correct `href`
+- [ ] Each specialty `<a>` has the correct visible label text
+- [ ] With `useReducedMotion` returning `true` — component still renders all text and links (no skip/hide)
+- [ ] Edge: single word name renders without crashing
+- [ ] Edge: empty `specialties` array renders an empty `<ul>` without crashing
+
+Run: `pnpm vitest run --project unit src/components/hero/hero.test.tsx`
+
+## Storybook Stories (`hero.stories.tsx`)
+
+- [ ] `Default` story — updated args include `name`, `tagline`, `specialties`; animation plays in Storybook canvas
+- [ ] `ReducedMotion` story — use `parameters: { a11y: ... }` or a decorator to simulate `prefers-reduced-motion: reduce`; confirm text is static and fully visible
+- [ ] `FoodHero` story — updated args include text props
+- [ ] A11y panel shows zero violations on all stories
+
+Run: `pnpm test:stories`
+
+## Manual Testing
+
+**Animation feel:**
+- [ ] Name words emerge cleanly one by one with no clipping artefacts
+- [ ] Inter-word spacing is preserved during animation (no words running together)
+- [ ] Tagline begins naturally after name settles
+- [ ] Specialty labels wipe up crisply after tagline
+- [ ] On page load (not Storybook), animation triggers exactly once
+
+**Reduced motion:**
+- [ ] Enable "Reduce motion" in OS or Chrome DevTools (`prefers-reduced-motion: reduce`)
+- [ ] All text is immediately visible, no animation plays
+
+**Responsive:**
+- [ ] At 375px: name wraps to 2 lines without overflow; labels wrap naturally
+- [ ] At 768px: comfortable intermediate layout
+- [ ] At 1280px: full layout as designed
+
+**Keyboard / focus:**
+- [ ] Tab reaches each specialty link
+- [ ] Focus ring visible (`focus-visible:ring-2 focus-visible:ring-accent`)
+- [ ] Links navigate correctly
+
+**Accessibility:**
+- [ ] Screen reader (VoiceOver / NVDA) announces full name string and full tagline string — not individual fragmented words
+- [ ] `<nav aria-label="Photography specialties">` appears as a distinct landmark
+
+## Test Data
+
+Storybook story args:
+```ts
+args: {
+  image: { src: '/images/food/70.jpg', alt: 'Neil Hurley Photography' },
+  name: 'Neil Hurley',
+  tagline: 'Commercial photographer based in Dublin',
+  specialties: [
+    { label: 'Food & Drink', href: '/food' },
+    { label: 'Advertising & Product', href: '/advertising' },
+  ],
+}
+```
+
+## Test Reporting & Coverage
+
+- `pnpm test:coverage` — confirm `hero.tsx` and `hero-content.tsx` at 100% line coverage
+- `pnpm test:stories` — Storybook a11y set to `'error'` mode; any violation fails CI

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:stories": "vitest run --project storybook"
   },
   "dependencies": {
+    "motion": "^11.18.2",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      motion:
+        specifier: ^11.18.2
+        version: 11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2366,6 +2369,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@11.18.2:
+    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -3063,6 +3080,26 @@ packages:
 
   module-alias@2.3.4:
     resolution: {integrity: sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==}
+
+  motion-dom@11.18.1:
+    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+
+  motion-utils@11.18.1:
+    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
+
+  motion@11.18.2:
+    resolution: {integrity: sha512-JLjvFDuFr42NFtcVoMAyC2sEjnpA8xpy6qWPyzQvCloznAyQ8FIXioxWfHiLtgYhoVpfUqSWpn1h9++skj9+Wg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -6665,6 +6702,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   fresh@0.5.2: {}
 
   fs.realpath@1.0.0: {}
@@ -7371,6 +7417,20 @@ snapshots:
       minimist: 1.2.8
 
   module-alias@2.3.4: {}
+
+  motion-dom@11.18.1:
+    dependencies:
+      motion-utils: 11.18.1
+
+  motion-utils@11.18.1: {}
+
+  motion@11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      framer-motion: 11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   mrmime@2.0.1: {}
 

--- a/resources/hero-overlapping.html
+++ b/resources/hero-overlapping.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Neil Hurley — Overlapping Frames Hero</title>
+<link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Outfit:wght@200;300;400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #f7f5f2;
+    --bg-alt: #efece7;
+    --text-primary: #1a1815;
+    --text-secondary: #7a756e;
+    --text-muted: #a8a29e;
+    --accent: #8b7355;
+    --border: #e0dbd4;
+    --serif: 'Libre Baskerville', Georgia, serif;
+    --sans: 'Outfit', system-ui, sans-serif;
+    --ease: cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: var(--sans);
+    background: var(--bg);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+
+  /* ─── Nav ─── */
+  nav {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 48px;
+    background: var(--bg);
+  }
+
+  nav .logo {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  nav .links {
+    display: flex;
+    gap: 32px;
+    list-style: none;
+  }
+
+  nav .links a {
+    font-family: var(--sans);
+    font-weight: 300;
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    text-decoration: none;
+    position: relative;
+    padding-bottom: 3px;
+  }
+
+  nav .links a::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 1px;
+    background: var(--accent);
+    transition: width 0.5s var(--ease);
+  }
+
+  nav .links a:hover { color: var(--text-primary); }
+  nav .links a:hover::after { width: 100%; }
+  nav .links a.active { color: var(--text-primary); }
+  nav .links a.active::after { width: 100%; }
+
+  /* ─── Hero ─── */
+  .hero {
+    position: relative;
+    height: 100vh;
+    min-height: 640px;
+    overflow: hidden;
+  }
+
+  /* ─── Frames ─── */
+  .frame {
+    position: absolute;
+    overflow: hidden;
+    border-radius: 2px;
+    background: var(--bg-alt);
+    will-change: transform;
+    transition: box-shadow 0.6s ease;
+  }
+
+  .frame img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    opacity: 0;
+    transition: opacity 1.2s ease;
+  }
+
+  .frame img.loaded { opacity: 1; }
+
+  /* Back frame — larger, right side, below nav */
+  .frame-back {
+    width: 52%;
+    height: 62%;
+    right: 6%;
+    top: 18%;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.06);
+    z-index: 1;
+  }
+
+  /* Front frame — smaller, left side, overlapping */
+  .frame-front {
+    width: 38%;
+    height: 52%;
+    left: 10%;
+    top: 26%;
+    box-shadow: 0 28px 72px rgba(0,0,0,0.1);
+    z-index: 3;
+  }
+
+  /* Accent frame — small, tucked below nav on right */
+  .frame-accent {
+    width: 18%;
+    height: 24%;
+    right: 4%;
+    top: 10%;
+    box-shadow: 0 12px 40px rgba(0,0,0,0.06);
+    z-index: 2;
+    opacity: 0;
+    animation: fadeInAccent 1.4s ease 0.8s forwards;
+  }
+
+  @keyframes fadeInAccent {
+    to { opacity: 1; }
+  }
+
+  /* ─── Frame decorative borders ─── */
+  .frame::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border: 1px solid rgba(255,255,255,0.15);
+    z-index: 2;
+    pointer-events: none;
+    border-radius: 2px;
+  }
+
+  /* ─── Text ─── */
+  .hero-text {
+    position: absolute;
+    bottom: 56px;
+    left: 48px;
+    z-index: 10;
+  }
+
+  .hero-text h1 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: clamp(2.4rem, 4.5vw, 3.6rem);
+    color: var(--text-primary);
+    line-height: 1.08;
+    letter-spacing: -0.01em;
+    opacity: 0;
+    transform: translateY(24px);
+    animation: textReveal 1s var(--ease) 0.3s forwards;
+  }
+
+  .hero-text h1 em {
+    font-style: italic;
+    color: var(--accent);
+  }
+
+  .hero-text .accent-line {
+    width: 0;
+    height: 2px;
+    background: var(--accent);
+    margin-top: 16px;
+    animation: lineGrow 0.8s var(--ease) 0.9s forwards;
+  }
+
+  @keyframes textReveal {
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes lineGrow {
+    to { width: 40px; }
+  }
+
+  /* ─── Scroll cue ─── */
+  .scroll-cue {
+    position: absolute;
+    bottom: 56px;
+    right: 48px;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    opacity: 0;
+    animation: textReveal 0.8s var(--ease) 1.6s forwards;
+  }
+
+  .scroll-cue span {
+    font-size: 0.58rem;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+
+  .scroll-cue .scroll-line {
+    width: 1px;
+    height: 36px;
+    background: linear-gradient(to bottom, var(--accent), transparent);
+    animation: scrollPulse 2.5s ease infinite 2s;
+  }
+
+  @keyframes scrollPulse {
+    0%, 100% { opacity: 0.3; transform: scaleY(0.5); }
+    50% { opacity: 1; transform: scaleY(1); }
+  }
+
+  /* ─── Subtle background texture ─── */
+  .hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0.02;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 256px;
+  }
+
+  /* ─── Dummy content below for scroll testing ─── */
+  .content-below {
+    padding: 80px 48px;
+    border-top: 1px solid var(--border);
+  }
+
+  .content-below .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 48px;
+  }
+
+  .content-below h2 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 2rem;
+    color: var(--text-primary);
+  }
+
+  .content-below h2 em {
+    font-style: italic;
+    color: var(--accent);
+  }
+
+  .content-below .view-link {
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    text-decoration: none;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 3px;
+  }
+
+  .placeholder-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+  }
+
+  .placeholder-grid .ph {
+    aspect-ratio: 4/5;
+    background: var(--bg-alt);
+    border-radius: 2px;
+  }
+
+  /* ─── Responsive ─── */
+  @media (max-width: 768px) {
+    nav { padding: 20px 24px; }
+    nav .links { display: none; }
+
+    .frame-back {
+      width: 65%;
+      height: 55%;
+      right: 4%;
+      top: 20%;
+    }
+
+    .frame-front {
+      width: 55%;
+      height: 45%;
+      left: 6%;
+      top: 30%;
+    }
+
+    .frame-accent {
+      width: 28%;
+      height: 22%;
+      right: 3%;
+      top: 8%;
+    }
+
+    .hero-text {
+      bottom: 40px;
+      left: 24px;
+    }
+
+    .scroll-cue { right: 24px; bottom: 40px; }
+    .content-below { padding: 48px 24px; }
+    .placeholder-grid { grid-template-columns: 1fr 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<!-- Navigation -->
+<nav>
+  <a href="#" class="logo">Neil Hurley</a>
+  <ul class="links">
+    <li><a href="#" class="active">Portfolio</a></li>
+    <li><a href="#">Food</a></li>
+    <li><a href="#">Advertising</a></li>
+    <li><a href="#">Clients</a></li>
+    <li><a href="#">Contact</a></li>
+  </ul>
+</nav>
+
+<!-- Hero -->
+<section class="hero" id="hero">
+  <div class="frame frame-back" data-speed="0.03">
+    <img id="img-back" alt="Neil Hurley Photography">
+  </div>
+  <div class="frame frame-front" data-speed="-0.05">
+    <img id="img-front" alt="Neil Hurley Photography">
+  </div>
+  <div class="frame frame-accent" data-speed="0.02">
+    <img id="img-accent" alt="Neil Hurley Photography">
+  </div>
+
+  <div class="hero-text">
+    <h1>Neil <em>Hurley</em></h1>
+    <div class="accent-line"></div>
+  </div>
+
+  <div class="scroll-cue">
+    <span>Scroll</span>
+    <div class="scroll-line"></div>
+  </div>
+</section>
+
+<!-- Content below for scroll context -->
+<section class="content-below">
+  <div class="section-header">
+    <h2>Food <em>&amp;</em> Drink</h2>
+    <a href="#" class="view-link">View Collection</a>
+  </div>
+  <div class="placeholder-grid">
+    <div class="ph"></div>
+    <div class="ph"></div>
+    <div class="ph"></div>
+  </div>
+</section>
+
+<script>
+  // ─── Image pool from Neil's actual portfolio ───
+  const imagePool = {
+    // A mix across all categories for variety
+    all: [
+      // Product
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/122.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/1021.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/1161.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/120.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/130.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/1231.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/73.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2019/01/71.jpg',
+      // Food
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/121.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2017/06/531.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2017/06/24.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2017/06/47.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2017/06/36.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2016/01/Food-0030-Brown-Thomas-Group-2016.jpg',
+      // Advertising
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/131.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/1281.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/127.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/126.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2020/04/124.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2019/01/69.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2019/01/61.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2018/05/01.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2018/05/04.jpg',
+      'https://www.neilhurley.com/wp-content/uploads/2017/10/49.jpg',
+    ]
+  };
+
+  // ─── Pick 3 unique random images ───
+  function pickRandom(pool, count) {
+    const shuffled = [...pool].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, count);
+  }
+
+  function loadImages() {
+    const [src1, src2, src3] = pickRandom(imagePool.all, 3);
+    const slots = [
+      { el: document.getElementById('img-back'), src: src1 },
+      { el: document.getElementById('img-front'), src: src2 },
+      { el: document.getElementById('img-accent'), src: src3 },
+    ];
+
+    slots.forEach(({ el, src }) => {
+      el.onload = () => el.classList.add('loaded');
+      el.src = src;
+    });
+  }
+
+  loadImages();
+
+  // ─── Parallax on scroll ───
+  const frames = document.querySelectorAll('.frame[data-speed]');
+  const hero = document.getElementById('hero');
+
+  let ticking = false;
+  let scrollY = 0;
+
+  function updateParallax() {
+    const heroRect = hero.getBoundingClientRect();
+    const heroTop = heroRect.top;
+    const progress = -heroTop; // how far we've scrolled past the hero top
+
+    frames.forEach(frame => {
+      const speed = parseFloat(frame.dataset.speed);
+      const yOffset = progress * speed;
+      frame.style.transform = `translateY(${yOffset}px)`;
+    });
+
+    ticking = false;
+  }
+
+  window.addEventListener('scroll', () => {
+    if (!ticking) {
+      requestAnimationFrame(updateParallax);
+      ticking = true;
+    }
+  });
+
+  // ─── Subtle mouse parallax (desktop only) ───
+  if (window.matchMedia('(min-width: 769px)').matches) {
+    let mouseX = 0.5;
+    let mouseY = 0.5;
+    let currentX = 0.5;
+    let currentY = 0.5;
+
+    hero.addEventListener('mousemove', (e) => {
+      const rect = hero.getBoundingClientRect();
+      mouseX = (e.clientX - rect.left) / rect.width;
+      mouseY = (e.clientY - rect.top) / rect.height;
+    });
+
+    function animateMouse() {
+      // Smooth lerp
+      currentX += (mouseX - currentX) * 0.04;
+      currentY += (mouseY - currentY) * 0.04;
+
+      const offsetX = (currentX - 0.5);
+      const offsetY = (currentY - 0.5);
+
+      const back = document.querySelector('.frame-back');
+      const front = document.querySelector('.frame-front');
+      const accent = document.querySelector('.frame-accent');
+
+      // Each frame moves at different intensity for depth
+      const scrollOffset = parseFloat(back.style.transform?.match(/translateY\((.+)px\)/)?.[1] || 0);
+
+      back.style.transform = `translate(${offsetX * -8}px, ${offsetY * -6 + parseFloat(back.dataset.speed) * (-hero.getBoundingClientRect().top)}px)`;
+      front.style.transform = `translate(${offsetX * 14}px, ${offsetY * 10 + parseFloat(front.dataset.speed) * (-hero.getBoundingClientRect().top)}px)`;
+      accent.style.transform = `translate(${offsetX * -5}px, ${offsetY * -4 + parseFloat(accent.dataset.speed) * (-hero.getBoundingClientRect().top)}px)`;
+
+      requestAnimationFrame(animateMouse);
+    }
+
+    animateMouse();
+  }
+
+  // ─── Reload button (for demo — shows random images) ───
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'r' || e.key === 'R') {
+      document.querySelectorAll('.frame img').forEach(img => img.classList.remove('loaded'));
+      setTimeout(loadImages, 300);
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,12 @@ export default function HomePage() {
   return (
     <>
       <h1 className="sr-only">Neil Hurley Photography</h1>
-      <Hero image={homeData.hero.image} />
+      <Hero
+        image={homeData.hero.image}
+        name={homeData.hero.name}
+        tagline={homeData.hero.tagline}
+        specialties={homeData.hero.specialties}
+      />
 
       
       <section className="bg-background px-6 py-20">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Hero } from '@/components/hero';
+import { HeroOverlapping } from '@/components/hero-overlapping';
 import { GalleryGrid } from '@/components/gallery-grid';
 import { SectionHeader } from '@/components/section-header';
 import { ClientGrid } from '@/components/client-grid';
@@ -32,15 +32,11 @@ const ADV_PREVIEW_ITEMS = 3;
 const CLIENTS_PREVIEW_COUNT = 8;
 
 export default function HomePage() {
+  const heroImagePool = [...foodData.items.map((i) => i.image), ...advertisingData.items.map((i) => i.image)];
+
   return (
     <>
-      <h1 className="sr-only">Neil Hurley Photography</h1>
-      <Hero
-        image={homeData.hero.image}
-        name={homeData.hero.name}
-        tagline={homeData.hero.tagline}
-        specialties={homeData.hero.specialties}
-      />
+      <HeroOverlapping name={homeData.hero.name} imagePool={heroImagePool} />
 
       
       <section className="bg-background px-6 py-20">

--- a/src/components/hero-overlapping/hero-overlapping.stories.tsx
+++ b/src/components/hero-overlapping/hero-overlapping.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { HeroOverlapping } from './hero-overlapping';
+import foodData from '@/data/food.json';
+import advertisingData from '@/data/advertising.json';
+
+const imagePool = [
+  ...foodData.items.map((item) => item.image),
+  ...advertisingData.items.map((item) => item.image),
+];
+
+/** Storybook metadata for HeroOverlapping stories. */
+const meta: Meta<typeof HeroOverlapping> = {
+  title: 'Components/HeroOverlapping',
+  component: HeroOverlapping,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof HeroOverlapping>;
+
+/** Default hero with three random images drawn from the combined food + advertising pool. */
+export const Default: Story = {
+  args: {
+    name: 'Neil Hurley',
+    imagePool,
+  },
+};
+
+/** Minimal pool (exactly 3 images) — verifies the component works at the minimum required pool size. */
+export const MinimalPool: Story = {
+  args: {
+    name: 'Neil Hurley',
+    imagePool: imagePool.slice(0, 3),
+  },
+};
+
+/** Rendered with reduced motion preference — all entrance and parallax animations are skipped. */
+export const ReducedMotion: Story = {
+  name: 'Reduced Motion',
+  parameters: {
+    motionSafe: false,
+  },
+  args: {
+    ...Default.args,
+  },
+};

--- a/src/components/hero-overlapping/hero-overlapping.test.tsx
+++ b/src/components/hero-overlapping/hero-overlapping.test.tsx
@@ -119,6 +119,14 @@ describe('HeroOverlapping', () => {
     expect(section).toBeInTheDocument();
   });
 
+  it('renders images with opacity-100 after requestAnimationFrame fires', () => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0; });
+    render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const images = screen.getAllByRole('img');
+    images.forEach((img) => expect(img.className).toContain('opacity-100'));
+    vi.unstubAllGlobals();
+  });
+
   it('does not update mouse values when reduced motion is preferred', () => {
     mockUseReducedMotion.mockReturnValue(true);
     mockMouseXSet.mockClear();

--- a/src/components/hero-overlapping/hero-overlapping.test.tsx
+++ b/src/components/hero-overlapping/hero-overlapping.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HeroOverlapping } from './hero-overlapping';
+import type { ImageType } from '@/components/types';
+
+const mockMotionDiv = vi.fn(({ children, className }: { children?: React.ReactNode; className?: string }) =>
+  React.createElement('div', { className }, children)
+);
+
+const mockUseReducedMotion = vi.fn(() => false);
+const mockMouseXSet = vi.fn();
+const mockMouseYSet = vi.fn();
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: (props: Parameters<typeof mockMotionDiv>[0]) => mockMotionDiv(props),
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+  useScroll: () => ({ scrollYProgress: 0 }),
+  useTransform: (...args: unknown[]) => {
+    if (typeof args[1] === 'function') {
+      // Multi-input form: useTransform([vals], fn)
+      if (Array.isArray(args[0])) {
+        (args[1] as (v: number[]) => number)([0, 0]);
+      } else {
+        // Single-input form: useTransform(motionValue, fn)
+        (args[1] as (v: number) => number)(0);
+      }
+    }
+    return 0;
+  },
+  useMotionValue: (initial: number) => {
+    if (initial === 0) {
+      // Return the first call's mock for mouseX, second for mouseY
+      return { set: mockMouseXSet };
+    }
+    return { set: vi.fn() };
+  },
+  useSpring: () => 0,
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, fill, priority, ...rest }: { src: string; alt: string; fill?: boolean; priority?: boolean; [key: string]: unknown }) =>
+    React.createElement('img', { src, alt, 'data-fill': fill, 'data-priority': priority, ...rest }),
+}));
+
+const imagePool: ImageType[] = [
+  { src: '/images/food/01.jpg', alt: 'Food image one' },
+  { src: '/images/food/02.jpg', alt: 'Food image two' },
+  { src: '/images/food/03.jpg', alt: 'Food image three' },
+  { src: '/images/food/04.jpg', alt: 'Food image four' },
+  { src: '/images/food/05.jpg', alt: 'Food image five' },
+];
+
+describe('HeroOverlapping', () => {
+  beforeEach(() => {
+    mockMotionDiv.mockClear();
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  it('renders the section element', () => {
+    const { container } = render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const section = container.querySelector('section');
+    expect(section).toBeInTheDocument();
+  });
+
+  it('renders the photographer name with first name and surname', () => {
+    render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toContain('Neil');
+    expect(heading.textContent).toContain('Hurley');
+  });
+
+  it('renders the surname in an em element', () => {
+    const { container } = render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const em = container.querySelector('h1 em');
+    expect(em).toBeInTheDocument();
+    expect(em?.textContent).toBe('Hurley');
+  });
+
+  it('renders exactly three frame images from the image pool', () => {
+    render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(3);
+    // All should have src values from the pool
+    const srcs = images.map((img) => img.getAttribute('src'));
+    srcs.forEach((src) => {
+      expect(imagePool.some((item) => item.src === src)).toBe(true);
+    });
+  });
+
+  it('renders the scroll cue with Scroll label', () => {
+    render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    expect(screen.getByText('Scroll')).toBeInTheDocument();
+  });
+
+  it('renders correctly with reduced motion preference', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const { container } = render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    expect(container.querySelector('section')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('picks three unique images from the pool', () => {
+    render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const images = screen.getAllByRole('img');
+    const srcs = images.map((img) => img.getAttribute('src'));
+    const uniqueSrcs = new Set(srcs);
+    expect(uniqueSrcs.size).toBe(3);
+  });
+
+  it('handles mousemove events on the section', () => {
+    const { container } = render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const section = container.querySelector('section')!;
+    // Simulate mouse move — should not throw
+    fireEvent.mouseMove(section, { clientX: 100, clientY: 100 });
+    expect(section).toBeInTheDocument();
+  });
+
+  it('does not update mouse values when reduced motion is preferred', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    mockMouseXSet.mockClear();
+    const { container } = render(<HeroOverlapping name="Neil Hurley" imagePool={imagePool} />);
+    const section = container.querySelector('section')!;
+    fireEvent.mouseMove(section, { clientX: 100, clientY: 100 });
+    expect(mockMouseXSet).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/hero-overlapping/hero-overlapping.tsx
+++ b/src/components/hero-overlapping/hero-overlapping.tsx
@@ -26,6 +26,9 @@ interface HeroFrameProps {
   enterDelay: number;
   priority?: boolean;
   shouldAnimate: boolean;
+  showImages: boolean;
+  /** Tailwind delay class for the image fade-in, e.g. 'delay-0' */
+  imageDelayClass: string;
 }
 
 function HeroFrame({
@@ -35,6 +38,8 @@ function HeroFrame({
   enterDelay,
   priority = false,
   shouldAnimate,
+  showImages,
+  imageDelayClass,
 }: HeroFrameProps) {
   return (
     <motion.div
@@ -51,7 +56,7 @@ function HeroFrame({
         alt={image.alt}
         fill
         sizes="(max-width: 768px) 65vw, 52vw"
-        className="object-cover"
+        className={`object-cover transition-opacity duration-700 ${imageDelayClass} ${showImages ? 'opacity-100' : 'opacity-0'}`}
         priority={priority}
       />
     </motion.div>
@@ -110,9 +115,11 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
     imagePool[1],
     imagePool[2],
   ]);
+  const [showImages, setShowImages] = useState(false);
 
   useEffect(() => {
     setFrames(pickThree(imagePool));
+    setShowImages(true);
     // imagePool is stable from the server component — intentionally omitted from deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -174,6 +181,8 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
         motionStyle={shouldAnimate ? { x: backMouseX, y: backFinalY } : {}}
         enterDelay={0}
         shouldAnimate={shouldAnimate}
+        showImages={showImages}
+        imageDelayClass="delay-0"
       />
 
       {/* Accent frame — small, top-right, hidden on mobile */}
@@ -183,6 +192,8 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
         motionStyle={shouldAnimate ? { x: accentMouseX, y: accentFinalY } : {}}
         enterDelay={0.8}
         shouldAnimate={shouldAnimate}
+        showImages={showImages}
+        imageDelayClass="delay-150"
       />
 
       {/* Front frame — smaller, left side, highest z */}
@@ -193,6 +204,8 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
         enterDelay={0.2}
         priority
         shouldAnimate={shouldAnimate}
+        showImages={showImages}
+        imageDelayClass="delay-300"
       />
 
       {/* Name text — bottom-left */}

--- a/src/components/hero-overlapping/hero-overlapping.tsx
+++ b/src/components/hero-overlapping/hero-overlapping.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+import {
+  motion,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+  useMotionValue,
+  useSpring,
+  type MotionValue,
+} from 'motion/react';
+import type { ImageType } from '@/components/types';
+
+function pickThree(pool: ImageType[]): [ImageType, ImageType, ImageType] {
+  const shuffled = [...pool].sort(() => Math.random() - 0.5);
+  return [shuffled[0], shuffled[1], shuffled[2]];
+}
+
+interface HeroFrameProps {
+  image: ImageType;
+  /** Tailwind classes for size/position/z-index */
+  className: string;
+  motionStyle: React.ComponentPropsWithoutRef<typeof motion.div>['style'];
+  enterDelay: number;
+  priority?: boolean;
+  shouldAnimate: boolean;
+}
+
+function HeroFrame({
+  image,
+  className,
+  motionStyle,
+  enterDelay,
+  priority = false,
+  shouldAnimate,
+}: HeroFrameProps) {
+  return (
+    <motion.div
+      className={`absolute overflow-hidden rounded-sm bg-surface ${className}`}
+      style={motionStyle}
+      initial={shouldAnimate ? { opacity: 0, y: 20 } : false}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8, delay: enterDelay, ease: [0.23, 1, 0.32, 1] }}
+    >
+      {/* Decorative inset border */}
+      <div className="absolute inset-0 border border-white/15 z-10 pointer-events-none rounded-sm" />
+      <Image
+        src={image.src}
+        alt={image.alt}
+        fill
+        sizes="(max-width: 768px) 65vw, 52vw"
+        className="object-cover"
+        priority={priority}
+      />
+    </motion.div>
+  );
+}
+
+interface HeroScrollCueProps {
+  opacity: MotionValue<number>;
+  shouldAnimate: boolean;
+}
+
+function HeroScrollCue({ opacity, shouldAnimate }: HeroScrollCueProps) {
+  return (
+    <motion.div style={{ opacity }}>
+      <motion.div
+        className="absolute bottom-14 right-12 z-10 flex flex-col items-center gap-1.5"
+        initial={shouldAnimate ? { opacity: 0 } : false}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.8, delay: 1.6, ease: [0.23, 1, 0.32, 1] }}
+      >
+        <span className="font-body text-[0.58rem] tracking-[0.25em] uppercase text-muted">
+          Scroll
+        </span>
+        <motion.div
+          className="w-px h-9 bg-gradient-to-b from-accent to-transparent"
+          animate={{ opacity: [0.3, 1, 0.3], scaleY: [0.5, 1, 0.5] }}
+          transition={{ duration: 2.5, ease: 'easeInOut', repeat: Infinity, repeatDelay: 2 }}
+        />
+      </motion.div>
+    </motion.div>
+  );
+}
+
+export interface HeroOverlappingProps {
+  /** The photographer's name. Surname is rendered in italic accent colour. */
+  name: string;
+  /**
+   * Pool of portfolio images to randomise from.
+   * The component picks 3 unique images on client mount — different every page load.
+   * Must contain at least 3 items.
+   */
+  imagePool: ImageType[];
+}
+
+/**
+ * Hero section with three overlapping photo frames, scroll parallax, and mouse parallax.
+ * Replaces the full-bleed Hero on the homepage.
+ */
+export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
+  const shouldAnimate = !useReducedMotion();
+  const sectionRef = useRef<HTMLElement>(null);
+
+  // Deterministic initial state for SSR — randomised after hydration in useEffect
+  const [frames, setFrames] = useState<[ImageType, ImageType, ImageType]>([
+    imagePool[0],
+    imagePool[1],
+    imagePool[2],
+  ]);
+
+  useEffect(() => {
+    setFrames(pickThree(imagePool));
+    // imagePool is stable from the server component — intentionally omitted from deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Scroll parallax
+  const { scrollYProgress } = useScroll({ target: sectionRef, offset: ['start start', 'end start'] });
+  const backScrollY = useTransform(scrollYProgress, [0, 1], [0, 60]);
+  const frontScrollY = useTransform(scrollYProgress, [0, 1], [0, -100]);
+  const accentScrollY = useTransform(scrollYProgress, [0, 1], [0, 40]);
+  const scrollCueOpacity = useTransform(scrollYProgress, [0, 0.15], [1, 0]);
+
+  // Mouse parallax
+  const mouseX = useMotionValue(0);
+  const mouseY = useMotionValue(0);
+  const smoothX = useSpring(mouseX, { stiffness: 80, damping: 20 });
+  const smoothY = useSpring(mouseY, { stiffness: 80, damping: 20 });
+
+  const backMouseX = useTransform(smoothX, (v) => v * -8);
+  const backMouseY = useTransform(smoothY, (v) => v * -6);
+  const frontMouseX = useTransform(smoothX, (v) => v * 14);
+  const frontMouseY = useTransform(smoothY, (v) => v * 10);
+  const accentMouseX = useTransform(smoothX, (v) => v * -5);
+  const accentMouseY = useTransform(smoothY, (v) => v * -4);
+
+  // Combine scroll + mouse Y per frame
+  const backFinalY = useTransform(
+    [backScrollY, backMouseY],
+    ([s, m]) => (s as number) + (m as number)
+  );
+  const frontFinalY = useTransform(
+    [frontScrollY, frontMouseY],
+    ([s, m]) => (s as number) + (m as number)
+  );
+  const accentFinalY = useTransform(
+    [accentScrollY, accentMouseY],
+    ([s, m]) => (s as number) + (m as number)
+  );
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLElement>) => {
+    if (!shouldAnimate) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    mouseX.set((e.clientX - rect.left) / rect.width - 0.5);
+    mouseY.set((e.clientY - rect.top) / rect.height - 0.5);
+  };
+
+  const [firstName, ...rest] = name.split(' ');
+  const lastName = rest.join(' ');
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative h-screen min-h-[640px] overflow-hidden bg-background"
+      onMouseMove={handleMouseMove}
+    >
+      {/* Back frame — larger, right side */}
+      <HeroFrame
+        image={frames[0]}
+        className="w-[52%] h-[62%] right-[6%] top-[18%] z-10 shadow-[0_20px_60px_rgba(0,0,0,0.06)]"
+        motionStyle={shouldAnimate ? { x: backMouseX, y: backFinalY } : {}}
+        enterDelay={0}
+        shouldAnimate={shouldAnimate}
+      />
+
+      {/* Accent frame — small, top-right, hidden on mobile */}
+      <HeroFrame
+        image={frames[2]}
+        className="w-[18%] h-[24%] right-[4%] top-[10%] z-20 shadow-[0_12px_40px_rgba(0,0,0,0.06)] hidden md:block"
+        motionStyle={shouldAnimate ? { x: accentMouseX, y: accentFinalY } : {}}
+        enterDelay={0.8}
+        shouldAnimate={shouldAnimate}
+      />
+
+      {/* Front frame — smaller, left side, highest z */}
+      <HeroFrame
+        image={frames[1]}
+        className="w-[38%] h-[52%] left-[10%] top-[26%] z-30 shadow-[0_28px_72px_rgba(0,0,0,0.10)]"
+        motionStyle={shouldAnimate ? { x: frontMouseX, y: frontFinalY } : {}}
+        enterDelay={0.2}
+        priority
+        shouldAnimate={shouldAnimate}
+      />
+
+      {/* Name text — bottom-left */}
+      <motion.div
+        className="absolute bottom-14 left-12 z-10"
+        initial={shouldAnimate ? { opacity: 0, y: 24 } : false}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 1, delay: 0.3, ease: [0.23, 1, 0.32, 1] }}
+      >
+        <h1 className="font-display font-normal text-[clamp(2.4rem,4.5vw,3.6rem)] text-primary leading-[1.08] tracking-[-0.01em]">
+          {firstName} <em className="italic text-accent">{lastName}</em>
+        </h1>
+        <motion.div
+          className="h-0.5 bg-accent mt-4"
+          initial={shouldAnimate ? { width: 0 } : { width: 40 }}
+          animate={{ width: 40 }}
+          transition={{ duration: 0.8, delay: 0.9, ease: [0.23, 1, 0.32, 1] }}
+        />
+      </motion.div>
+
+      {/* Scroll cue — bottom-right */}
+      <HeroScrollCue opacity={scrollCueOpacity} shouldAnimate={shouldAnimate} />
+    </section>
+  );
+}

--- a/src/components/hero-overlapping/hero-overlapping.tsx
+++ b/src/components/hero-overlapping/hero-overlapping.tsx
@@ -18,6 +18,8 @@ function pickThree(pool: ImageType[]): [ImageType, ImageType, ImageType] {
   return [shuffled[0], shuffled[1], shuffled[2]];
 }
 
+type ImageState = 'hidden' | 'ready' | 'visible';
+
 interface HeroFrameProps {
   image: ImageType;
   /** Tailwind classes for size/position/z-index */
@@ -26,8 +28,8 @@ interface HeroFrameProps {
   enterDelay: number;
   priority?: boolean;
   shouldAnimate: boolean;
-  showImages: boolean;
-  /** Tailwind delay class for the image fade-in, e.g. 'delay-0' */
+  imageState: ImageState;
+  /** Tailwind delay class for the staggered image fade-in, e.g. 'delay-0' */
   imageDelayClass: string;
 }
 
@@ -38,7 +40,7 @@ function HeroFrame({
   enterDelay,
   priority = false,
   shouldAnimate,
-  showImages,
+  imageState,
   imageDelayClass,
 }: HeroFrameProps) {
   return (
@@ -51,14 +53,16 @@ function HeroFrame({
     >
       {/* Decorative inset border */}
       <div className="absolute inset-0 border border-white/15 z-10 pointer-events-none rounded-sm" />
-      <Image
-        src={image.src}
-        alt={image.alt}
-        fill
-        sizes="(max-width: 768px) 65vw, 52vw"
-        className={`object-cover transition-opacity duration-700 ${imageDelayClass} ${showImages ? 'opacity-100' : 'opacity-0'}`}
-        priority={priority}
-      />
+      {imageState !== 'hidden' && (
+        <Image
+          src={image.src}
+          alt={image.alt}
+          fill
+          sizes="(max-width: 768px) 65vw, 52vw"
+          className={`object-cover transition-opacity duration-700 ${imageDelayClass} ${imageState === 'visible' ? 'opacity-100' : 'opacity-0'}`}
+          priority={priority}
+        />
+      )}
     </motion.div>
   );
 }
@@ -109,17 +113,18 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
   const shouldAnimate = !useReducedMotion();
   const sectionRef = useRef<HTMLElement>(null);
 
-  // Deterministic initial state for SSR — randomised after hydration in useEffect
+  // No images rendered on SSR — randomised and faded in on client only
   const [frames, setFrames] = useState<[ImageType, ImageType, ImageType]>([
     imagePool[0],
     imagePool[1],
     imagePool[2],
   ]);
-  const [showImages, setShowImages] = useState(false);
+  const [imageState, setImageState] = useState<ImageState>('hidden');
 
   useEffect(() => {
     setFrames(pickThree(imagePool));
-    setShowImages(true);
+    setImageState('ready'); // mounts <Image> tags into DOM at opacity-0
+    requestAnimationFrame(() => setImageState('visible')); // triggers CSS transition
     // imagePool is stable from the server component — intentionally omitted from deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -181,7 +186,7 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
         motionStyle={shouldAnimate ? { x: backMouseX, y: backFinalY } : {}}
         enterDelay={0}
         shouldAnimate={shouldAnimate}
-        showImages={showImages}
+        imageState={imageState}
         imageDelayClass="delay-0"
       />
 
@@ -192,7 +197,7 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
         motionStyle={shouldAnimate ? { x: accentMouseX, y: accentFinalY } : {}}
         enterDelay={0.8}
         shouldAnimate={shouldAnimate}
-        showImages={showImages}
+        imageState={imageState}
         imageDelayClass="delay-150"
       />
 
@@ -204,7 +209,7 @@ export function HeroOverlapping({ name, imagePool }: HeroOverlappingProps) {
         enterDelay={0.2}
         priority
         shouldAnimate={shouldAnimate}
-        showImages={showImages}
+        imageState={imageState}
         imageDelayClass="delay-300"
       />
 

--- a/src/components/hero-overlapping/index.ts
+++ b/src/components/hero-overlapping/index.ts
@@ -1,0 +1,1 @@
+export { HeroOverlapping } from './hero-overlapping';

--- a/src/components/hero/hero-content.tsx
+++ b/src/components/hero/hero-content.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { motion, useReducedMotion } from 'motion/react';
+import Link from 'next/link';
+import type { LinkType } from '@/components/types';
+
+interface RevealWordsProps {
+  text: string;
+  delay: number;
+  staggerMs: number;
+  durationMs: number;
+  shouldAnimate: boolean;
+}
+
+function RevealWords({ text, delay, staggerMs, durationMs, shouldAnimate }: RevealWordsProps) {
+  const words = text.split(' ');
+  return (
+    <>
+      {words.map((word, i) => (
+        <span key={i} style={{ display: 'inline-block', overflow: 'hidden' }}>
+          <motion.span
+            style={{ display: 'inline-block' }}
+            initial={shouldAnimate ? { y: '110%' } : false}
+            animate={{ y: 0 }}
+            transition={{
+              duration: durationMs / 1000,
+              delay: (delay + i * staggerMs) / 1000,
+              ease: [0.16, 1, 0.3, 1],
+            }}
+          >
+            {word}
+          </motion.span>
+          {i < words.length - 1 ? ' ' : null}
+        </span>
+      ))}
+    </>
+  );
+}
+
+interface HeroContentProps {
+  name: string;
+  tagline: string;
+  specialties: LinkType[];
+}
+
+/**
+ * Animated hero text overlay with staggered word reveals for name, tagline, and specialty links.
+ */
+export function HeroContent({ name, tagline, specialties }: HeroContentProps) {
+  const shouldAnimate = !useReducedMotion();
+
+  const nameWords = name.split(' ').length;
+  const taglineDelay = nameWords * 60 + 100;
+
+  const taglineWords = tagline.split(' ').length;
+  const specialtiesBaseDelay = taglineDelay + taglineWords * 40 + 80;
+
+  return (
+    <div>
+      <p className="font-display text-3xl md:text-5xl text-card leading-tight">
+        <RevealWords
+          text={name}
+          delay={0}
+          staggerMs={60}
+          durationMs={500}
+          shouldAnimate={shouldAnimate}
+        />
+      </p>
+      <p className="font-body text-sm md:text-base text-card/75 mt-2">
+        <RevealWords
+          text={tagline}
+          delay={taglineDelay}
+          staggerMs={40}
+          durationMs={400}
+          shouldAnimate={shouldAnimate}
+        />
+      </p>
+      <ul className="flex flex-wrap gap-2 mt-4">
+        {specialties.map((s, i) => (
+          <motion.li
+            key={s.href}
+            initial={shouldAnimate ? { clipPath: 'inset(0 0 100% 0)' } : false}
+            animate={{ clipPath: 'inset(0 0 0% 0)' }}
+            transition={{
+              duration: 0.4,
+              delay: (specialtiesBaseDelay + i * 80) / 1000,
+            }}
+          >
+            <Link
+              href={s.href}
+              className="font-body text-xs md:text-sm text-card border border-card/40 rounded-full px-3 py-1 hover:bg-card/10 transition-colors"
+            >
+              {s.label}
+            </Link>
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/hero/hero.stories.tsx
+++ b/src/components/hero/hero.stories.tsx
@@ -16,10 +16,13 @@ const meta: Meta<typeof Hero> = {
 export default meta;
 type Story = StoryObj<typeof Hero>;
 
-/** Default hero with a full-width background image. */
+/** Default hero with a full-width background image, name, tagline, and specialty links. */
 export const Default: Story = {
   args: {
     image: homeData.hero.image,
+    name: homeData.hero.name,
+    tagline: homeData.hero.tagline,
+    specialties: homeData.hero.specialties,
   },
 };
 
@@ -27,5 +30,20 @@ export const Default: Story = {
 export const FoodHero: Story = {
   args: {
     image: foodData.items[0].image,
+    name: homeData.hero.name,
+    tagline: homeData.hero.tagline,
+    specialties: homeData.hero.specialties,
+  },
+};
+
+/** Hero rendered with reduced motion preference (animations should be skipped). */
+export const ReducedMotion: Story = {
+  name: 'Reduced Motion',
+  parameters: {
+    backgrounds: { default: 'dark' },
+    motionSafe: false,
+  },
+  args: {
+    ...Default.args,
   },
 };

--- a/src/components/hero/hero.test.tsx
+++ b/src/components/hero/hero.test.tsx
@@ -1,36 +1,86 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Hero } from './hero';
 
+vi.mock('motion/react', () => ({
+  motion: {
+    span: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) =>
+      React.createElement('span', props, children),
+    li: ({ children, ...props }: React.HTMLAttributes<HTMLLIElement>) =>
+      React.createElement('li', props, children),
+  },
+  useReducedMotion: () => false,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement('a', { href }, children),
+}));
+
 describe('Hero', () => {
-  const defaultImage = {
-    src: '/resources/images/hero/main.jpg',
-    alt: 'Neil Hurley Photography',
+  const defaultProps = {
+    image: { src: '/images/food/70.jpg', alt: 'Neil Hurley Photography' },
+    name: 'Neil Hurley',
+    tagline: 'Commercial photographer based in Dublin',
+    specialties: [
+      { label: 'Food & Drink', href: '/food' },
+      { label: 'Advertising & Product', href: '/advertising' },
+    ],
   };
 
   it('renders the hero image with correct alt text', () => {
-    render(<Hero image={defaultImage} />);
+    render(<Hero {...defaultProps} />);
     const img = screen.getByRole('img', { name: 'Neil Hurley Photography' });
     expect(img).toBeInTheDocument();
   });
 
   it('renders image with fill layout', () => {
-    render(<Hero image={defaultImage} />);
+    render(<Hero {...defaultProps} />);
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('src');
   });
 
   it('renders with correct section classes', () => {
-    const { container } = render(<Hero image={defaultImage} />);
+    const { container } = render(<Hero {...defaultProps} />);
     const section = container.querySelector('section');
     expect(section?.className).toContain('h-[85vh]');
-    expect(section?.className).toContain('min-h-[500px]');
     expect(section?.className).toContain('overflow-hidden');
   });
 
   it('renders the gradient overlay', () => {
-    const { container } = render(<Hero image={defaultImage} />);
-    const overlay = container.querySelector('.bg-gradient-to-t');
+    const { container } = render(<Hero {...defaultProps} />);
+    const overlay = container.querySelector('[class*="bg-linear"]');
     expect(overlay).toBeInTheDocument();
+  });
+
+  it('renders name', () => {
+    const { container } = render(<Hero {...defaultProps} />);
+    const nameEl = container.querySelector('p.font-display');
+    expect(nameEl?.textContent?.replace(/\s+/g, ' ').trim()).toBe('Neil Hurley');
+  });
+
+  it('renders tagline', () => {
+    const { container } = render(<Hero {...defaultProps} />);
+    const taglineEl = container.querySelector('p.font-body');
+    expect(taglineEl?.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      'Commercial photographer based in Dublin'
+    );
+  });
+
+  it('renders specialty links with correct hrefs', () => {
+    render(<Hero {...defaultProps} />);
+    const foodLink = screen.getByRole('link', { name: 'Food & Drink' });
+    expect(foodLink).toBeInTheDocument();
+    expect(foodLink).toHaveAttribute('href', '/food');
+
+    const adLink = screen.getByRole('link', { name: 'Advertising & Product' });
+    expect(adLink).toBeInTheDocument();
+    expect(adLink).toHaveAttribute('href', '/advertising');
+  });
+
+  it('renders no links when specialties is empty', () => {
+    render(<Hero {...defaultProps} specialties={[]} />);
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
 });

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
-import type { ImageType } from '@/components/types';
+import type { ImageType, LinkType } from '@/components/types';
+import { HeroContent } from './hero-content';
 
 /**
  * Props for the Hero component.
@@ -7,15 +8,21 @@ import type { ImageType } from '@/components/types';
 interface HeroProps {
   /** Hero background image. */
   image: ImageType;
+  /** Photographer name displayed in the overlay. */
+  name: string;
+  /** Short positioning tagline. */
+  tagline: string;
+  /** Specialty area labels with hrefs, rendered as navigation links. */
+  specialties: LinkType[];
 }
 
 /**
  * Full-width hero section with a background image and gradient overlay.
  *
  * @example
- * <Hero image={{ src: '/images/hero.jpg', alt: 'Hero' }} />
+ * <Hero image={{ src: '/images/hero.jpg', alt: 'Hero' }} name="Neil Hurley" tagline="Commercial photographer" specialties={[]} />
  */
-export function Hero({ image }: HeroProps) {
+export function Hero({ image, name, tagline, specialties }: HeroProps) {
   return (
     <section className="relative h-[85vh] min-h-125 w-full overflow-hidden">
       <Image
@@ -28,6 +35,9 @@ export function Hero({ image }: HeroProps) {
         sizes="100vw"
       />
       <div className="absolute inset-0 bg-linear-to-t from-background to-transparent pointer-events-none" />
+      <div className="absolute bottom-0 left-0 right-0 px-6 pb-10 md:pb-14">
+        <HeroContent name={name} tagline={tagline} specialties={specialties} />
+      </div>
     </section>
   );
 }

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -3,7 +3,13 @@
     "image": {
       "src": "/images/food/70.jpg",
       "alt": "Neil Hurley Photography"
-    }
+    },
+    "name": "Neil Hurley",
+    "tagline": "Commercial photographer based in Dublin",
+    "specialties": [
+      { "label": "Food & Drink", "href": "/food" },
+      { "label": "Advertising & Product", "href": "/advertising" }
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary

- Adds \`name\`, \`tagline\`, and \`specialties\` fields to \`home.json\` hero object
- New \`HeroContent\` client component with per-word \`translateY\` reveal animations via Motion
- Specialty area pill links (\`/food\`, \`/advertising\`) with \`clip-path\` wipe-up reveal
- \`useReducedMotion\` respected — animations skipped cleanly for accessibility
- Unit tests updated with Motion mock; Storybook stories updated with \`ReducedMotion\` story

## Test plan

- [ ] \`pnpm test\` — all unit tests pass
- [ ] \`pnpm typecheck\` — zero TypeScript errors
- [ ] \`pnpm lint\` — zero ESLint errors
- [ ] Verify Vercel preview: hero shows name, tagline, and two specialty links
- [ ] Check reduced-motion mode in OS settings — text renders at rest state immediately
- [ ] Check WCAG AA contrast on hero text in Storybook a11y panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)